### PR TITLE
Add claimRewards matches preview invariant ENG-1254

### DIFF
--- a/test/invariants/UnstakerInvariants.t.sol
+++ b/test/invariants/UnstakerInvariants.t.sol
@@ -54,7 +54,7 @@ abstract contract UnstakerInvariantsWithStateTransitions is InvariantTestBaseWit
 
     // An unstake triggers `claimRewards`, so we need to calculate the rewards to be claimed before the unstake.
     PreviewClaimableRewards memory actorPreviewClaimableRewards_ =
-      rewardsManagerHandler.getActorRewardsToBeClaimed(unstakedStakePoolId_, actor_)[0];
+      rewardsManagerHandler.previewClaimableRewardsForActor(unstakedStakePoolId_, actor_)[0];
     for (uint16 rewardPoolId_ = 0; rewardPoolId_ < numRewardPools; rewardPoolId_++) {
       actorRewardsToBeClaimed[rewardsManager.rewardPools(rewardPoolId_).asset] +=
         actorPreviewClaimableRewards_.claimableRewardsData[rewardPoolId_].amount;

--- a/test/invariants/handlers/RewardsManagerHandler.sol
+++ b/test/invariants/handlers/RewardsManagerHandler.sol
@@ -696,7 +696,7 @@ contract RewardsManagerHandler is TestBase {
     return initIndex_;
   }
 
-  function getActorRewardsToBeClaimed(uint16 stakePoolId_, address actor_)
+  function previewClaimableRewardsForActor(uint16 stakePoolId_, address actor_)
     public
     view
     returns (PreviewClaimableRewards[] memory reservePoolClaimableRewards_)


### PR DESCRIPTION
Added an invariant to check that claim rewards matches previewed claimable rewards -- relevant for state transitions because we don't drip internally when PAUSED.

This also address ENG-1254 because we know have full coverage for the rewards invariants in both PAUSED and ACTIVE states across `RewardsAccountingInvariants`, `RewardsDistributorInvariants`, and `StateTransitionInvariants`.