### PR TITLE
Rename cumulativeClaimedRewards

### DIFF
--- a/src/lib/RewardsDistributor.sol
+++ b/src/lib/RewardsDistributor.sol
@@ -187,7 +187,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     uint256 stkReceiptTokenSupply_,
     uint256 rewardsWeight_
   ) internal pure returns (ClaimableRewardsData memory nextClaimableRewardsData_) {
-    nextClaimableRewardsData_.cumulativeClaimedRewards = claimableRewardsData_.cumulativeClaimedRewards;
+    nextClaimableRewardsData_.cumulativeClaimableRewards = claimableRewardsData_.cumulativeClaimableRewards;
     nextClaimableRewardsData_.indexSnapshot = claimableRewardsData_.indexSnapshot;
     // If `stkReceiptTokenSupply_ == 0`, then we get a divide by zero error if we try to update the index snapshot. To
     // avoid this, we wait until the `stkReceiptTokenSupply_ > 0`, to apply all accumulated unclaimed dripped rewards to
@@ -196,9 +196,9 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     if (stkReceiptTokenSupply_ > 0) {
       // Round down, in favor of leaving assets in the pool.
       uint256 unclaimedDrippedRewards_ = cumulativeDrippedRewards_.mulDivDown(rewardsWeight_, MathConstants.ZOC)
-        - claimableRewardsData_.cumulativeClaimedRewards;
+        - claimableRewardsData_.cumulativeClaimableRewards;
 
-      nextClaimableRewardsData_.cumulativeClaimedRewards += unclaimedDrippedRewards_;
+      nextClaimableRewardsData_.cumulativeClaimableRewards += unclaimedDrippedRewards_;
       // Round down, in favor of leaving assets in the claimable reward pool.
       nextClaimableRewardsData_.indexSnapshot += unclaimedDrippedRewards_.divWadDown(stkReceiptTokenSupply_);
     }
@@ -327,7 +327,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
           stakePool_.rewardsWeight
         );
         claimableRewards[j][i] =
-          ClaimableRewardsData({cumulativeClaimedRewards: 0, indexSnapshot: claimableRewardsData_.indexSnapshot});
+          ClaimableRewardsData({cumulativeClaimableRewards: 0, indexSnapshot: claimableRewardsData_.indexSnapshot});
       }
     }
   }

--- a/src/lib/structs/Pools.sol
+++ b/src/lib/structs/Pools.sol
@@ -18,8 +18,9 @@ struct StakePool {
   IERC20 asset;
   // The receipt token for the stake pool.
   IReceiptToken stkReceiptToken;
-  // The weighting of each stkReceiptToken's claim to all reward pools in terms of a ZOC. Must sum to ZOC. e.g.
-  // stkReceiptTokenA = 10%, means stake pool A is eligible for up to 10% of rewards dripped from all reward pools.
+  // The weighting of each stake pool's claim to all reward pools in terms of a ZOC. Must sum to ZOC. e.g.
+  // stakePoolA.rewardsWeight = 10%, means stake pool A is eligible for up to 10% of rewards dripped from all reward
+  // pools.
   uint16 rewardsWeight;
 }
 

--- a/src/lib/structs/Rewards.sol
+++ b/src/lib/structs/Rewards.sol
@@ -14,9 +14,8 @@ struct UserRewardsData {
 
 // Used to track the total rewards all users are entitled to for a given (stake pool, reward pool) pair.
 struct ClaimableRewardsData {
-  // The cumulative amount of rewards that have been claimed on behalf of all users. This value is reset to 0 on each
-  // config update.
-  uint256 cumulativeClaimedRewards;
+  // The cumulative amount of rewards that are claimable. This value is reset to 0 on each config update.
+  uint256 cumulativeClaimableRewards;
   // The index snapshot the relevant claimable rewards data, when the cumulative claimed rewards were updated. The index
   // snapshot must update each time the cumulative claimed rewards are updated.
   uint256 indexSnapshot;

--- a/test/RewardsDistributor.t.sol
+++ b/test/RewardsDistributor.t.sol
@@ -713,7 +713,7 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
 
       // Check that claimable rewards are updated.
       assertGt(newClaimableRewards_[i].indexSnapshot, oldClaimableRewards_[i].indexSnapshot);
-      assertGt(newClaimableRewards_[i].cumulativeClaimedRewards, oldClaimableRewards_[i].cumulativeClaimedRewards);
+      assertGt(newClaimableRewards_[i].cumulativeClaimableRewards, oldClaimableRewards_[i].cumulativeClaimableRewards);
 
       // Check that user rewards are updated and transferred to receiver.
       assertEq(rewardAsset_.balanceOf(receiver_), accruedRewards_);
@@ -987,7 +987,7 @@ contract RewardsDistributorStkReceiptTokenTransferUnitTest is RewardsDistributor
 
 contract RewardsDistributorDripAndResetCumulativeValuesUnitTest is RewardsDistributorUnitTest {
   function _expectedClaimableRewardsData(uint256 indexSnapshot) internal pure returns (ClaimableRewardsData memory) {
-    return ClaimableRewardsData({indexSnapshot: indexSnapshot, cumulativeClaimedRewards: 0});
+    return ClaimableRewardsData({indexSnapshot: indexSnapshot, cumulativeClaimableRewards: 0});
   }
 
   function test_dripAndResetCumulativeRewardsValues_ZeroStkReceiptTokenSupply() public {
@@ -1056,7 +1056,7 @@ contract RewardsDistributorDripAndResetCumulativeValuesUnitTest is RewardsDistri
     for (uint16 i = 0; i < numRewardPools_; i++) {
       assertEq(rewardPools_[i].cumulativeDrippedRewards, 0);
       for (uint16 j = 0; j < numStakePools_; j++) {
-        assertEq(claimableRewards_[j][i].cumulativeClaimedRewards, 0);
+        assertEq(claimableRewards_[j][i].cumulativeClaimableRewards, 0);
       }
     }
   }
@@ -1111,10 +1111,12 @@ contract TestableRewardsDistributor is RewardsDistributor, Staker, Depositor, Re
     uint16 stakePoolId_,
     uint16 rewardPoolId_,
     uint128 claimableRewardsIndex_,
-    uint128 cumulativeClaimedRewards_
+    uint128 cumulativeClaimableRewards_
   ) external {
-    claimableRewards[stakePoolId_][rewardPoolId_] =
-      ClaimableRewardsData({indexSnapshot: claimableRewardsIndex_, cumulativeClaimedRewards: cumulativeClaimedRewards_});
+    claimableRewards[stakePoolId_][rewardPoolId_] = ClaimableRewardsData({
+      indexSnapshot: claimableRewardsIndex_,
+      cumulativeClaimableRewards: cumulativeClaimableRewards_
+    });
   }
 
   function mockRegisterStkReceiptToken(uint16 stakePoolId_, IReceiptToken stkReceiptToken_) external {

--- a/test/Staker.t.sol
+++ b/test/Staker.t.sol
@@ -35,7 +35,7 @@ contract StakerUnitTest is TestBase {
   MockERC20 mockDepositReceiptToken = new MockERC20("Mock Cozy Deposit Receipt Token", "cozyDep", 6);
   TestableStaker component = new TestableStaker();
   uint256 cumulativeDrippedRewards_ = 290e18;
-  uint256 cumulativeClaimedRewards_ = 90e18;
+  uint256 cumulativeClaimableRewards_ = 90e18;
   uint256 initialIndexSnapshot_ = 11;
 
   event Staked(
@@ -69,7 +69,7 @@ contract StakerUnitTest is TestBase {
     AssetPool memory initialRewardsPool_ = AssetPool({amount: cumulativeDrippedRewards_});
     component.mockAddAssetPool(IERC20(address(mockAsset)), initialRewardsPool_);
     mockAsset.mint(address(component), cumulativeDrippedRewards_);
-    component.mockSetClaimableRewardsData(0, 0, initialIndexSnapshot_, cumulativeClaimedRewards_);
+    component.mockSetClaimableRewardsData(0, 0, initialIndexSnapshot_, cumulativeClaimableRewards_);
 
     deal(address(mockStakeAsset), address(component), initialStakeAmount);
     mockStkReceiptToken.mint(address(0), initialStakeAmount);
@@ -114,9 +114,9 @@ contract StakerUnitTest is TestBase {
     assertEq(
       finalClaimableRewardsData_.indexSnapshot,
       initialIndexSnapshot_
-        + uint256(cumulativeDrippedRewards_ - cumulativeClaimedRewards_).divWadDown(initialStakeAmount)
+        + uint256(cumulativeDrippedRewards_ - cumulativeClaimableRewards_).divWadDown(initialStakeAmount)
     );
-    assertEq(finalClaimableRewardsData_.cumulativeClaimedRewards, cumulativeDrippedRewards_);
+    assertEq(finalClaimableRewardsData_.cumulativeClaimableRewards, cumulativeDrippedRewards_);
 
     assertEq(mockStakeAsset.balanceOf(staker_), 0);
     assertEq(mockStkReceiptToken.balanceOf(receiver_), amountToStake_);
@@ -153,7 +153,7 @@ contract StakerUnitTest is TestBase {
     // rewards
     // should not change.
     assertEq(finalClaimableRewardsData_.indexSnapshot, initialIndexSnapshot_);
-    assertEq(finalClaimableRewardsData_.cumulativeClaimedRewards, cumulativeClaimedRewards_);
+    assertEq(finalClaimableRewardsData_.cumulativeClaimableRewards, cumulativeClaimableRewards_);
     assertEq(mockStakeAsset.balanceOf(staker_), 0);
     assertEq(mockStkReceiptToken.balanceOf(receiver_), amountToStake_);
   }
@@ -262,7 +262,7 @@ contract StakerUnitTest is TestBase {
     // rewards
     // should not change.
     assertEq(finalClaimableRewardsData_.indexSnapshot, initialIndexSnapshot_);
-    assertEq(finalClaimableRewardsData_.cumulativeClaimedRewards, cumulativeClaimedRewards_);
+    assertEq(finalClaimableRewardsData_.cumulativeClaimableRewards, cumulativeClaimableRewards_);
     assertEq(mockStakeAsset.balanceOf(staker_), 0);
     assertEq(mockStkReceiptToken.balanceOf(receiver_), amountToStake_);
   }
@@ -388,9 +388,9 @@ contract StakerUnitTest is TestBase {
     assertEq(
       finalClaimableRewardsData_.indexSnapshot,
       initialIndexSnapshot_
-        + uint256(cumulativeDrippedRewards_ - cumulativeClaimedRewards_).divWadDown(initialStakeAmount)
+        + uint256(cumulativeDrippedRewards_ - cumulativeClaimableRewards_).divWadDown(initialStakeAmount)
     );
-    assertEq(finalClaimableRewardsData_.cumulativeClaimedRewards, cumulativeDrippedRewards_);
+    assertEq(finalClaimableRewardsData_.cumulativeClaimableRewards, cumulativeDrippedRewards_);
   }
 
   function test_unstake_unstakePartial() public {
@@ -437,9 +437,9 @@ contract StakerUnitTest is TestBase {
     assertEq(
       finalClaimableRewardsData_.indexSnapshot,
       initialIndexSnapshot_
-        + uint256(cumulativeDrippedRewards_ - cumulativeClaimedRewards_).divWadDown(initialStakeAmount)
+        + uint256(cumulativeDrippedRewards_ - cumulativeClaimableRewards_).divWadDown(initialStakeAmount)
     );
-    assertEq(finalClaimableRewardsData_.cumulativeClaimedRewards, cumulativeDrippedRewards_);
+    assertEq(finalClaimableRewardsData_.cumulativeClaimableRewards, cumulativeDrippedRewards_);
   }
 
   function test_unstake_canUnstakeTotalInMultipleUnstakes() external {
@@ -506,9 +506,9 @@ contract StakerUnitTest is TestBase {
     assertEq(
       finalClaimableRewardsData_.indexSnapshot,
       initialIndexSnapshot_
-        + uint256(cumulativeDrippedRewards_ - cumulativeClaimedRewards_).divWadDown(initialStakeAmount)
+        + uint256(cumulativeDrippedRewards_ - cumulativeClaimableRewards_).divWadDown(initialStakeAmount)
     );
-    assertEq(finalClaimableRewardsData_.cumulativeClaimedRewards, cumulativeDrippedRewards_);
+    assertEq(finalClaimableRewardsData_.cumulativeClaimableRewards, cumulativeDrippedRewards_);
   }
 
   function test_unstake_cannotUnstakeIfAmountIsZero() external {
@@ -604,11 +604,11 @@ contract TestableStaker is Staker, Depositor, RewardsDistributor, RewardsManager
     uint16 stakePoolId_,
     uint16 rewardPoolid_,
     uint256 indexSnapshot_,
-    uint256 cumulativeClaimedRewards_
+    uint256 cumulativeClaimableRewards_
   ) external {
     claimableRewards[stakePoolId_][rewardPoolid_] = ClaimableRewardsData({
       indexSnapshot: indexSnapshot_.safeCastTo128(),
-      cumulativeClaimedRewards: cumulativeClaimedRewards_
+      cumulativeClaimableRewards: cumulativeClaimableRewards_
     });
   }
 

--- a/test/invariants/ConfiguratorInvariants.t.sol
+++ b/test/invariants/ConfiguratorInvariants.t.sol
@@ -294,8 +294,8 @@ abstract contract ConfiguratorInvariantsWithStateTransitions is InvariantTestBas
       for (uint8 stakePoolId_ = 0; stakePoolId_ < numStakePools; stakePoolId_++) {
         ClaimableRewardsData memory claimableRewards_ = rewardsManager.claimableRewards(stakePoolId_, rewardPoolId_);
         require(
-          claimableRewards_.cumulativeClaimedRewards == 0,
-          "Claimable rewards cumulative claimed rewards must be reset to 0 before a config update."
+          claimableRewards_.cumulativeClaimableRewards == 0,
+          "Claimable rewards cumulative claimable rewards must be reset to 0 before a config update."
         );
         require(
           claimableRewards_.indexSnapshot >= preClaimableRewards_[stakePoolId_][rewardPoolId_].indexSnapshot,

--- a/test/invariants/RewardsAccountingInvariants.t.sol
+++ b/test/invariants/RewardsAccountingInvariants.t.sol
@@ -16,30 +16,30 @@ import {
 abstract contract RewardsAccountingInvariantsWithStateTransitions is InvariantTestBaseWithStateTransitions {
   using FixedPointMathLib for uint256;
 
-  function invariant_cumulativeClaimedRewardsLteScaledCumulativeDrippedRewards()
+  function invariant_cumulativeClaimableRewardsLteScaledCumulativeDrippedRewards()
     public
     syncCurrentTimestamp(rewardsManagerHandler)
   {
     for (uint16 rewardPoolId_ = 0; rewardPoolId_ < numRewardPools; rewardPoolId_++) {
       uint256 cumulativeDrippedRewards_ = rewardsManager.rewardPools(rewardPoolId_).cumulativeDrippedRewards;
-      uint256 sumCumulativeClaimedRewards_ = 0;
+      uint256 sumCumulativeClaimableRewards_ = 0;
 
       for (uint16 stakePoolId_ = 0; stakePoolId_ < numStakePools; stakePoolId_++) {
-        uint256 cumulativeClaimedRewards_ =
-          rewardsManager.claimableRewards(stakePoolId_, rewardPoolId_).cumulativeClaimedRewards;
-        sumCumulativeClaimedRewards_ += cumulativeClaimedRewards_;
+        uint256 cumulativeClaimableRewards_ =
+          rewardsManager.claimableRewards(stakePoolId_, rewardPoolId_).cumulativeClaimableRewards;
+        sumCumulativeClaimableRewards_ += cumulativeClaimableRewards_;
 
         uint256 rewardsWeight_ = rewardsManager.stakePools(stakePoolId_).rewardsWeight;
         uint256 scaledCumulativeDrippedRewards_ =
           cumulativeDrippedRewards_.mulDivDown(rewardsWeight_, MathConstants.ZOC);
         require(
-          cumulativeClaimedRewards_ <= scaledCumulativeDrippedRewards_,
+          cumulativeClaimableRewards_ <= scaledCumulativeDrippedRewards_,
           string.concat(
             "Invariant Violated: The cumulative claimed rewards for a specific (stake pool, reward pool) pair must be less than or equal to the scaled cumulative dripped rewards for the pair.",
             " scaledCumulativeDrippedRewards: ",
             Strings.toString(scaledCumulativeDrippedRewards_),
-            ", cumulativeClaimedRewards: ",
-            Strings.toString(cumulativeClaimedRewards_),
+            ", cumulativeClaimableRewards: ",
+            Strings.toString(cumulativeClaimableRewards_),
             ", stakePoolId: ",
             Strings.toString(stakePoolId_),
             ", rewardPoolId: ",
@@ -49,11 +49,11 @@ abstract contract RewardsAccountingInvariantsWithStateTransitions is InvariantTe
       }
 
       require(
-        sumCumulativeClaimedRewards_ <= cumulativeDrippedRewards_,
+        sumCumulativeClaimableRewards_ <= cumulativeDrippedRewards_,
         string.concat(
           "Invariant Violated: Invariant Violated: The sum of every stake pool's cumulative claimed rewards from a reward pool must be less than or equal to the cumulative dripped rewards from the reward pool.",
           " totalClaimedRewards: ",
-          Strings.toString(sumCumulativeClaimedRewards_),
+          Strings.toString(sumCumulativeClaimableRewards_),
           ", cumulativeDrippedRewards: ",
           Strings.toString(cumulativeDrippedRewards_),
           ", rewardPoolId: ",
@@ -76,17 +76,17 @@ abstract contract RewardsAccountingInvariantsWithStateTransitions is InvariantTe
     for (uint16 stakePoolId_ = 0; stakePoolId_ < numStakePools; stakePoolId_++) {
       for (uint16 rewardPoolId_ = 0; rewardPoolId_ < numRewardPools; rewardPoolId_++) {
         uint256 sumUserAccruedRewards_ = sumUserAccruedRewards[stakePoolId_][rewardPoolId_];
-        uint256 cumulativeClaimedRewards_ =
-          rewardsManager.claimableRewards(stakePoolId_, rewardPoolId_).cumulativeClaimedRewards;
+        uint256 cumulativeClaimableRewards_ =
+          rewardsManager.claimableRewards(stakePoolId_, rewardPoolId_).cumulativeClaimableRewards;
 
         require(
-          sumUserAccruedRewards_ <= cumulativeClaimedRewards_,
+          sumUserAccruedRewards_ <= cumulativeClaimableRewards_,
           string.concat(
             "Invariant Violated: The sum of user accrued rewards for a (stake pool, reward pool) pair must be less than or equal to the cumulative claimed rewards for the pair.",
             " sumUserAccruedRewards: ",
             Strings.toString(sumUserAccruedRewards_),
             ", cumulativeClaimedRewards: ",
-            Strings.toString(cumulativeClaimedRewards_),
+            Strings.toString(cumulativeClaimableRewards_),
             ", stakePoolId: ",
             Strings.toString(stakePoolId_),
             ", rewardPoolId: ",

--- a/test/invariants/RewardsDistributorInvariants.t.sol
+++ b/test/invariants/RewardsDistributorInvariants.t.sol
@@ -187,17 +187,18 @@ abstract contract RewardsDistributorInvariantsWithStateTransitions is InvariantT
     for (uint16 rewardPoolId_ = 0; rewardPoolId_ < numRewardPools; rewardPoolId_++) {
       _invariant_dripRewardPoolChanged(preRewardPools_[rewardPoolId_], postRewardPools_[rewardPoolId_]);
 
-      uint256 preCumulativeClaimedRewards_ = preClaimableRewards_[stakePoolId_][rewardPoolId_].cumulativeClaimedRewards;
-      uint256 postCumulativeClaimedRewards_ =
-        postClaimableRewards_[stakePoolId_][rewardPoolId_].cumulativeClaimedRewards;
+      uint256 preCumulativeClaimableRewards_ =
+        preClaimableRewards_[stakePoolId_][rewardPoolId_].cumulativeClaimableRewards;
+      uint256 postCumulativeClaimableRewards_ =
+        postClaimableRewards_[stakePoolId_][rewardPoolId_].cumulativeClaimableRewards;
       require(
-        preCumulativeClaimedRewards_ <= postCumulativeClaimedRewards_,
+        preCumulativeClaimableRewards_ <= postCumulativeClaimableRewards_,
         string.concat(
           "Invariant Violated: The post-cumulative claimed rewards must be greater than or equal to the pre-cumulative claimed rewards after claimRewards.",
           " preCumulativeClaimedRewards: ",
-          Strings.toString(preCumulativeClaimedRewards_),
+          Strings.toString(preCumulativeClaimableRewards_),
           ", postCumulativeClaimedRewards: ",
-          Strings.toString(postCumulativeClaimedRewards_),
+          Strings.toString(postCumulativeClaimableRewards_),
           ", stakePoolId: ",
           Strings.toString(stakePoolId_),
           ", rewardPoolId: ",
@@ -208,13 +209,13 @@ abstract contract RewardsDistributorInvariantsWithStateTransitions is InvariantT
       uint256 scaledCumulativeDrippedRewards_ =
         postRewardPools_[rewardPoolId_].cumulativeDrippedRewards.mulDivDown(stakePool_.rewardsWeight, MathConstants.ZOC);
       require(
-        postCumulativeClaimedRewards_ == scaledCumulativeDrippedRewards_,
+        postCumulativeClaimableRewards_ == scaledCumulativeDrippedRewards_,
         string.concat(
           "Invariant Violated: The post-cumulative claimed rewards must be equal to the scaled cumulative dripped rewards after claimRewards.",
           " scaledCumulativeDrippedRewards: ",
           Strings.toString(scaledCumulativeDrippedRewards_),
           ", postCumulativeClaimedRewards: ",
-          Strings.toString(postCumulativeClaimedRewards_),
+          Strings.toString(postCumulativeClaimableRewards_),
           ", stakePoolId: ",
           Strings.toString(stakePoolId_),
           ", rewardPoolId: ",

--- a/test/utils/TestAssertions.sol
+++ b/test/utils/TestAssertions.sol
@@ -86,9 +86,9 @@ abstract contract TestAssertions is Test {
 
   function assertEq(ClaimableRewardsData memory actual_, ClaimableRewardsData memory expected_) internal {
     assertEq(
-      actual_.cumulativeClaimedRewards,
-      expected_.cumulativeClaimedRewards,
-      "ClaimableRewardsData.cumulativeClaimedRewards"
+      actual_.cumulativeClaimableRewards,
+      expected_.cumulativeClaimableRewards,
+      "ClaimableRewardsData.cumulativeClaimableRewards"
     );
     assertEq(actual_.indexSnapshot, expected_.indexSnapshot, "ClaimableRewardsData.indexSnapshot");
   }


### PR DESCRIPTION
Quick PR -- realized while working on docs, probably makes most sense to call it `ClaimableRewardsData.cumulativeClaimableRewards` instead of `ClaimableRewardsData.cumulativeClaimedRewards`