### PR TITLE
Add rewards claim fee and test suite fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,6 @@
 [submodule "lib/cozy-safety-module-models"]
 	path = lib/cozy-safety-module-models
 	url = https://github.com/Cozy-Finance/cozy-safety-module-models
-[submodule "lib/cozy-safety-module-shared"]
-	path = lib/cozy-safety-module-shared
-	url = https://github.com/Cozy-Finance/cozy-safety-module-shared
+[submodule "lib/cozy-safety-module-libs"]
+	path = lib/cozy-safety-module-libs
+	url = https://github.com/Cozy-Finance/cozy-safety-module-libs

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,7 +11,7 @@ remappings = [
   "@chainlink/=lib/chainlink/",
   "solmate/=lib/solmate/src/",
   "cozy-safety-module-models/=lib/cozy-safety-module-models/src",
-  "cozy-safety-module-shared/=lib/cozy-safety-module-shared/src",
+  "cozy-safety-module-libs/=lib/cozy-safety-module-libs/src",
 ]
 fs_permissions = [{ access = "read", path = "./script/input"}]
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,6 +14,7 @@ remappings = [
   "cozy-safety-module-libs/=lib/cozy-safety-module-libs/src",
 ]
 fs_permissions = [{ access = "read", path = "./script/input"}]
+allow_internal_expect_revert = true
 
 [profile.default.fuzz]
 runs = 1024

--- a/script/DeployProtocol.s.sol
+++ b/script/DeployProtocol.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {IReceiptTokenFactory} from "cozy-safety-module-shared/interfaces/IReceiptTokenFactory.sol";
-import {ReceiptToken} from "cozy-safety-module-shared/ReceiptToken.sol";
-import {ReceiptTokenFactory} from "cozy-safety-module-shared/ReceiptTokenFactory.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {IReceiptTokenFactory} from "cozy-safety-module-libs/interfaces/IReceiptTokenFactory.sol";
+import {ReceiptToken} from "cozy-safety-module-libs/ReceiptToken.sol";
+import {ReceiptTokenFactory} from "cozy-safety-module-libs/ReceiptTokenFactory.sol";
 import {console2} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {ScriptUtils} from "./utils/ScriptUtils.sol";

--- a/script/DeployProtocol.s.sol
+++ b/script/DeployProtocol.s.sol
@@ -64,6 +64,9 @@ contract DeployProtocol is ScriptUtils {
   uint16 allowedStakePools;
   uint16 allowedRewardPools;
 
+  // The default claim fee.
+  uint16 claimFee;
+
   // Core contracts to deploy.
   CozyManager manager;
   RewardsManager rewardsManagerLogic;
@@ -87,6 +90,7 @@ contract DeployProtocol is ScriptUtils {
     // -------- Pool Limits --------
     allowedStakePools = uint16(json_.readUint(".allowedStakePools"));
     allowedRewardPools = uint16(json_.readUint(".allowedRewardPools"));
+    claimFee = uint16(json_.readUint(".claimFee"));
 
     // -------------------------------------
     // -------- Address Computation --------
@@ -111,7 +115,7 @@ contract DeployProtocol is ScriptUtils {
 
     // -------- Deploy: CozyManager --------
     vm.broadcast();
-    manager = new CozyManager(owner, pauser, computedAddrRewardsManagerFactory_);
+    manager = new CozyManager(owner, pauser, computedAddrRewardsManagerFactory_, claimFee);
     console2.log("CozyRewardsManager deployed:", address(manager));
     require(address(manager) == address(computedAddrManager_), "CozyManager address mismatch");
 

--- a/script/input/10/deploy-protocol-production.json
+++ b/script/input/10/deploy-protocol-production.json
@@ -2,5 +2,6 @@
   "owner": "0x8c1e18b36fa8094cb56155a348f136241b217a9a",
   "pauser": "0x032b8eAE4dA80397A596d4B9a68487bF11D6588D",
   "allowedRewardPools": 20,
-  "allowedStakePools": 30
+  "allowedStakePools": 30,
+  "claimFee": 100
 }

--- a/script/input/10/deploy-protocol-test.json
+++ b/script/input/10/deploy-protocol-test.json
@@ -2,5 +2,6 @@
   "owner": "0x8c1e18b36fa8094cb56155a348f136241b217a9a",
   "pauser": "0x032b8eAE4dA80397A596d4B9a68487bF11D6588D",
   "allowedRewardPools": 20,
-  "allowedStakePools": 30
+  "allowedStakePools": 30,
+  "claimFee": 100
 }

--- a/script/utils/ScriptUtils.sol
+++ b/script/utils/ScriptUtils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {Script} from "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 

--- a/src/CozyManager.sol
+++ b/src/CozyManager.sol
@@ -2,24 +2,77 @@
 pragma solidity 0.8.22;
 
 import {Governable} from "cozy-safety-module-libs/lib/Governable.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
 import {ICozyManager} from "./interfaces/ICozyManager.sol";
 import {IRewardsManager} from "./interfaces/IRewardsManager.sol";
 import {IRewardsManagerFactory} from "./interfaces/IRewardsManagerFactory.sol";
 import {RewardPoolConfig, StakePoolConfig} from "./lib/structs/Configs.sol";
 
 contract CozyManager is Governable, ICozyManager {
+  struct ClaimFeeLookup {
+    uint16 claimFee;
+    bool exists;
+  }
+
   /// @notice Cozy protocol RewardsManagerFactory.
   IRewardsManagerFactory public immutable rewardsManagerFactory;
+
+  /// @notice The default claim fee used for RewardsManagers, represented as a ZOC (e.g. 500 = 5%).
+  uint16 public claimFee;
+
+  /// @notice Override claim fees for specific RewardsManagers.
+  mapping(IRewardsManager => ClaimFeeLookup) public overrideClaimFees;
 
   /// @param owner_ The Cozy protocol owner.
   /// @param pauser_ The Cozy protocol pauser.
   /// @param rewardsManagerFactory_ The Cozy protocol RewardsManagerFactory.
-  constructor(address owner_, address pauser_, IRewardsManagerFactory rewardsManagerFactory_) {
+  /// @param claimFee_ The default claim fee used for RewardsManagers, represented as a ZOC (e.g. 500 = 5%).
+  constructor(address owner_, address pauser_, IRewardsManagerFactory rewardsManagerFactory_, uint16 claimFee_) {
     _assertAddressNotZero(owner_);
     _assertAddressNotZero(address(rewardsManagerFactory_));
     __initGovernable(owner_, pauser_);
 
     rewardsManagerFactory = rewardsManagerFactory_;
+    _updateClaimFee(claimFee_);
+  }
+
+  // -------------------------------------------------
+  // --------------- Claim Fee Management ------------
+  // -------------------------------------------------
+
+  /// @notice Update the default claim fee used for RewardsManagers.
+  /// @param claimFee_ The new default claim fee.
+  function updateClaimFee(uint16 claimFee_) external onlyOwner {
+    _updateClaimFee(claimFee_);
+  }
+
+  /// @notice Update the claim fee for a specific RewardsManager.
+  /// @param rewardsManager_ The RewardsManager to update the claim fee for.
+  /// @param claimFee_ The new fee claim fee for the RewardsManager.
+  function updateOverrideClaimFee(IRewardsManager rewardsManager_, uint16 claimFee_) external onlyOwner {
+    overrideClaimFees[rewardsManager_] = ClaimFeeLookup({exists: true, claimFee: claimFee_});
+    emit OverrideClaimFeeUpdated(rewardsManager_, claimFee_);
+  }
+
+  /// @notice Reset the override claim fee for the specified RewardsManager back to the default.
+  /// @param rewardsManager_ The RewardsManager to update the claim fee for.
+  function resetOverrideClaimFee(IRewardsManager rewardsManager_) external onlyOwner {
+    delete overrideClaimFees[rewardsManager_];
+    emit OverrideClaimFeeUpdated(rewardsManager_, claimFee);
+  }
+
+  /// @notice For the specified RewardsManager, returns the claim fee.
+  function getClaimFee(IRewardsManager rewardsManager_) public view returns (uint16) {
+    ClaimFeeLookup memory overrideClaimFee_ = overrideClaimFees[rewardsManager_];
+    if (overrideClaimFee_.exists) return overrideClaimFee_.claimFee;
+    else return claimFee;
+  }
+
+  /// @dev Executes the claim fee update.
+  function _updateClaimFee(uint16 claimFee_) internal {
+    if (claimFee_ > MathConstants.ZOC) revert InvalidClaimFee();
+    claimFee = claimFee_;
+    emit ClaimFeeUpdated(claimFee_);
   }
 
   // -------------------------------------------------

--- a/src/CozyManager.sol
+++ b/src/CozyManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {Governable} from "cozy-safety-module-shared/lib/Governable.sol";
+import {Governable} from "cozy-safety-module-libs/lib/Governable.sol";
 import {ICozyManager} from "./interfaces/ICozyManager.sol";
 import {IRewardsManager} from "./interfaces/IRewardsManager.sol";
 import {IRewardsManagerFactory} from "./interfaces/IRewardsManagerFactory.sol";

--- a/src/CozyManager.sol
+++ b/src/CozyManager.sol
@@ -50,6 +50,7 @@ contract CozyManager is Governable, ICozyManager {
   /// @param rewardsManager_ The RewardsManager to update the claim fee for.
   /// @param claimFee_ The new fee claim fee for the RewardsManager.
   function updateOverrideClaimFee(IRewardsManager rewardsManager_, uint16 claimFee_) external onlyOwner {
+    if (claimFee_ > MathConstants.ZOC) revert InvalidClaimFee();
     overrideClaimFees[rewardsManager_] = ClaimFeeLookup({exists: true, claimFee: claimFee_});
     emit OverrideClaimFeeUpdated(rewardsManager_, claimFee_);
   }

--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IReceiptTokenFactory} from "cozy-safety-module-shared/interfaces/IReceiptTokenFactory.sol";
+import {IReceiptTokenFactory} from "cozy-safety-module-libs/interfaces/IReceiptTokenFactory.sol";
 import {Configurator} from "./lib/Configurator.sol";
 import {ConfiguratorLib} from "./lib/ConfiguratorLib.sol";
 import {RewardsManagerCommon} from "./lib/RewardsManagerCommon.sol";

--- a/src/StkReceiptToken.sol
+++ b/src/StkReceiptToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {ReceiptToken} from "cozy-safety-module-shared/ReceiptToken.sol";
+import {ReceiptToken} from "cozy-safety-module-libs/ReceiptToken.sol";
 import {IRewardsManager} from "./interfaces/IRewardsManager.sol";
 
 contract StkReceiptToken is ReceiptToken {

--- a/src/interfaces/IConfiguratorEvents.sol
+++ b/src/interfaces/IConfiguratorEvents.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
 import {RewardPoolConfig, StakePoolConfig} from "../lib/structs/Configs.sol";
 
 interface IConfiguratorEvents {

--- a/src/interfaces/ICozyManager.sol
+++ b/src/interfaces/ICozyManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import {IGovernable} from "cozy-safety-module-shared/interfaces/IGovernable.sol";
+import {IGovernable} from "cozy-safety-module-libs/interfaces/IGovernable.sol";
 import {IRewardsManager} from "./IRewardsManager.sol";
 import {IRewardsManagerFactory} from "./IRewardsManagerFactory.sol";
 import {RewardPoolConfig, StakePoolConfig} from "../lib/structs/Configs.sol";

--- a/src/interfaces/ICozyManager.sol
+++ b/src/interfaces/ICozyManager.sol
@@ -4,11 +4,31 @@ pragma solidity ^0.8.0;
 import {IGovernable} from "cozy-safety-module-libs/interfaces/IGovernable.sol";
 import {IRewardsManager} from "./IRewardsManager.sol";
 import {IRewardsManagerFactory} from "./IRewardsManagerFactory.sol";
+import {ICozyManagerEvents} from "./ICozyManagerEvents.sol";
 import {RewardPoolConfig, StakePoolConfig} from "../lib/structs/Configs.sol";
 
-interface ICozyManager is IGovernable {
+interface ICozyManager is IGovernable, ICozyManagerEvents {
   /// @notice Cozy protocol RewardsManagerFactory.
   function rewardsManagerFactory() external view returns (IRewardsManagerFactory rewardsManagerFactory_);
+
+  /// @notice The default claim fee used for RewardsManagers, represented as a ZOC (e.g. 500 = 5%).
+  function claimFee() external view returns (uint16);
+
+  /// @notice Update the default claim fee used for RewardsManagers.
+  /// @param claimFee_ The new default claim fee.
+  function updateClaimFee(uint16 claimFee_) external;
+
+  /// @notice Update the claim fee for a specific RewardsManager.
+  /// @param rewardsManager_ The RewardsManager to update the claim fee for.
+  /// @param claimFee_ The new fee claim fee for the RewardsManager.
+  function updateOverrideClaimFee(IRewardsManager rewardsManager_, uint16 claimFee_) external;
+
+  /// @notice Reset the override claim fee for the specified RewardsManager back to the default.
+  /// @param rewardsManager_ The RewardsManager to update the claim fee for.
+  function resetOverrideClaimFee(IRewardsManager rewardsManager_) external;
+
+  /// @notice For the specified RewardsManager, returns the claim fee.
+  function getClaimFee(IRewardsManager rewardsManager_) external view returns (uint16);
 
   /// @notice Batch pauses rewardsManagers_. The manager's pauser or owner can perform this action.
   /// @param rewardsManagers_ The array of rewards managers to pause.

--- a/src/interfaces/ICozyManagerEvents.sol
+++ b/src/interfaces/ICozyManagerEvents.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IRewardsManager} from "./IRewardsManager.sol";
+
+interface ICozyManagerEvents {
+  /// @dev Emitted when the default claim fee is updated by the Cozy Rewards Manager protocol owner.
+  event ClaimFeeUpdated(uint16 claimFee_);
+
+  /// @dev Emitted when an override claim fee is updated by the Cozy Rewards Manager protocol owner.
+  event OverrideClaimFeeUpdated(IRewardsManager indexed rewardsManager_, uint16 claimFee_);
+
+  /// @dev Emitted when an invalid claim fee is provided.
+  error InvalidClaimFee();
+}

--- a/src/interfaces/IDepositorEvents.sol
+++ b/src/interfaces/IDepositorEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
 
 interface IDepositorEvents {
   /// @notice Emitted when a user deposits.

--- a/src/interfaces/IRewardsManager.sol
+++ b/src/interfaces/IRewardsManager.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {IReceiptTokenFactory} from "cozy-safety-module-shared/interfaces/IReceiptTokenFactory.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {IReceiptTokenFactory} from "cozy-safety-module-libs/interfaces/IReceiptTokenFactory.sol";
 import {StakePool, RewardPool, AssetPool} from "../lib/structs/Pools.sol";
 import {ClaimableRewardsData, PreviewClaimableRewards, UserRewardsData} from "../lib/structs/Rewards.sol";
 import {RewardsManagerState} from "../lib/RewardsManagerStates.sol";

--- a/src/lib/Configurator.sol
+++ b/src/lib/Configurator.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {Governable} from "cozy-safety-module-shared/lib/Governable.sol";
+import {Governable} from "cozy-safety-module-libs/lib/Governable.sol";
 import {ConfiguratorLib} from "./ConfiguratorLib.sol";
 import {RewardsManagerCommon} from "./RewardsManagerCommon.sol";
 import {IConfiguratorErrors} from "../interfaces/IConfiguratorErrors.sol";

--- a/src/lib/ConfiguratorLib.sol
+++ b/src/lib/ConfiguratorLib.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {IReceiptTokenFactory} from "cozy-safety-module-shared/interfaces/IReceiptTokenFactory.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {IReceiptTokenFactory} from "cozy-safety-module-libs/interfaces/IReceiptTokenFactory.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {IConfiguratorErrors} from "../interfaces/IConfiguratorErrors.sol";
 import {IConfiguratorEvents} from "../interfaces/IConfiguratorEvents.sol";
 import {StakePool, RewardPool, IdLookup} from "./structs/Pools.sol";

--- a/src/lib/Depositor.sol
+++ b/src/lib/Depositor.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {SafeERC20} from "cozy-safety-module-shared/lib/SafeERC20.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {SafeERC20} from "cozy-safety-module-libs/lib/SafeERC20.sol";
 import {IDepositorErrors} from "../interfaces/IDepositorErrors.sol";
 import {IDepositorEvents} from "../interfaces/IDepositorEvents.sol";
 import {RewardsManagerState} from "./RewardsManagerStates.sol";

--- a/src/lib/RewardsDistributor.sol
+++ b/src/lib/RewardsDistributor.sol
@@ -128,10 +128,9 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     mapping(uint16 => ClaimableRewardsData) storage claimableRewards_ = claimableRewards[stakePoolId_];
 
     // Fully accure historical rewards for both users given their current stkReceiptToken balances. Moving forward all
-    // rewards
-    // will accrue based on: (1) the stkReceiptToken balances of the `from_` and `to_` address after the transfer, (2)
-    // the
-    // current claimable reward index snapshots.
+    // rewards will accrue based on: (1) the stkReceiptToken balances of the `from_` and `to_` address after the
+    // transfer, (2)
+    // the current claimable reward index snapshots.
     _updateUserRewards(stkReceiptToken_.balanceOf(from_), claimableRewards_, userRewards[stakePoolId_][from_]);
     _updateUserRewards(stkReceiptToken_.balanceOf(to_), claimableRewards_, userRewards[stakePoolId_][to_]);
   }

--- a/src/lib/RewardsDistributor.sol
+++ b/src/lib/RewardsDistributor.sol
@@ -296,12 +296,13 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
         ).accruedRewards
         : _previewAddUserRewardsData(ownerStkReceiptTokenBalance_, previewNextClaimableRewardsData_.indexSnapshot)
           .accruedRewards;
-      uint256 claimedRewardsAmount_ = accruedRewards_ - _computeClaimFeeAmount(accruedRewards_, claimFee_);
+      uint256 claimFeeAmount_ = _computeClaimFeeAmount(accruedRewards_, claimFee_);
 
       claimableRewardsData_[i] = PreviewClaimableRewardsData({
         rewardPoolId: i,
         asset: nextRewardDrips_[i].rewardAsset,
-        amount: claimedRewardsAmount_
+        amount: accruedRewards_ - claimFeeAmount_,
+        claimFeeAmount: claimFeeAmount_
       });
     }
 

--- a/src/lib/RewardsDistributor.sol
+++ b/src/lib/RewardsDistributor.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {Ownable} from "cozy-safety-module-shared/lib/Ownable.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {SafeERC20} from "cozy-safety-module-shared/lib/SafeERC20.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {Ownable} from "cozy-safety-module-libs/lib/Ownable.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {SafeERC20} from "cozy-safety-module-libs/lib/SafeERC20.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {StakePool, AssetPool} from "./structs/Pools.sol";
 import {RewardsManagerCommon} from "./RewardsManagerCommon.sol";

--- a/src/lib/RewardsDistributor.sol
+++ b/src/lib/RewardsDistributor.sol
@@ -30,6 +30,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     uint16 indexed rewardPoolId_,
     IERC20 rewardAsset_,
     uint256 amount_,
+    uint256 claimFeeAmount_,
     address indexed owner_,
     address receiver_
   );
@@ -251,7 +252,13 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     args_.rewardAsset.safeTransfer(args_.receiver, claimedAmount_);
 
     emit ClaimedRewards(
-      args_.stakePoolId, args_.rewardPoolId, args_.rewardAsset, claimedAmount_, args_.owner, args_.receiver
+      args_.stakePoolId,
+      args_.rewardPoolId,
+      args_.rewardAsset,
+      claimedAmount_,
+      claimFeeAmount_,
+      args_.owner,
+      args_.receiver
     );
   }
 

--- a/src/lib/RewardsDistributor.sol
+++ b/src/lib/RewardsDistributor.sol
@@ -8,6 +8,7 @@ import {Ownable} from "cozy-safety-module-libs/lib/Ownable.sol";
 import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
 import {SafeERC20} from "cozy-safety-module-libs/lib/SafeERC20.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
+import {IRewardsManager} from "../interfaces/IRewardsManager.sol";
 import {StakePool, AssetPool} from "./structs/Pools.sol";
 import {RewardsManagerCommon} from "./RewardsManagerCommon.sol";
 import {RewardsManagerState} from "./RewardsManagerStates.sol";
@@ -46,13 +47,14 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     uint256 numUserRewardAssets;
   }
 
-  struct TransferClaimedRewardsArgs {
+  struct FinalizeClaimedRewardsArgs {
     uint16 stakePoolId;
     uint16 rewardPoolId;
     IERC20 rewardAsset;
     address owner;
     address receiver;
     uint256 amount;
+    uint16 claimFee;
   }
 
   /// @notice Drip rewards for all reward pools.
@@ -147,6 +149,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     IReceiptToken stkReceiptToken_ = stakePool_.stkReceiptToken;
     mapping(uint16 => ClaimableRewardsData) storage claimableRewards_ = claimableRewards[args_.stakePoolId];
     UserRewardsData[] storage userRewards_ = userRewards[args_.stakePoolId][args_.owner];
+    uint16 claimFee_ = cozyManager.getClaimFee(IRewardsManager(address(this)));
 
     ClaimRewardsData memory claimRewardsData_ = ClaimRewardsData({
       userStkReceiptTokenBalance: stkReceiptToken_.balanceOf(args_.owner),
@@ -160,7 +163,8 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     // (1) Drip from the reward pool since time may have passed since the last drip.
     // (2) Compute and update the next claimable rewards data for the (stake pool, reward pool) pair.
     // (3) Update the user's accrued rewards data for the (stake pool, reward pool) pair.
-    // (4) Transfer the user's accrued rewards from the reward pool to the receiver.
+    // (4) Transfer the user's accrued rewards from the reward pool to the receiver, while potentially taking a fee (if
+    // set) that is sent to the protocol owner
     for (uint16 rewardPoolId_ = 0; rewardPoolId_ < claimRewardsData_.numRewardAssets; rewardPoolId_++) {
       // Step (1)
       RewardPool storage rewardPool_ = rewardPools[rewardPoolId_];
@@ -192,8 +196,8 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
         }
 
         // Step (4)
-        _transferClaimedRewards(
-          TransferClaimedRewardsArgs(
+        _finalizeClaimedRewards(
+          FinalizeClaimedRewardsArgs(
             args_.stakePoolId,
             rewardPoolId_,
             rewardPool_.asset,
@@ -202,7 +206,8 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
             oldAccruedRewards_
               + _getUserAccruedRewards(
                 claimRewardsData_.userStkReceiptTokenBalance, newClaimableRewardsData_.indexSnapshot, oldIndexSnapshot_
-              )
+              ),
+            claimFee_
           )
         );
       }
@@ -233,12 +238,20 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     }
   }
 
-  function _transferClaimedRewards(TransferClaimedRewardsArgs memory args_) internal {
+  function _finalizeClaimedRewards(FinalizeClaimedRewardsArgs memory args_) internal {
     if (args_.amount == 0) return;
     assetPools[args_.rewardAsset].amount -= args_.amount;
-    args_.rewardAsset.safeTransfer(args_.receiver, args_.amount);
+
+    // Transfer the claim fee to the protocol owner
+    uint256 claimFeeAmount_ = _computeClaimFeeAmount(args_.amount, args_.claimFee);
+    if (claimFeeAmount_ > 0) args_.rewardAsset.safeTransfer(cozyManager.owner(), claimFeeAmount_);
+    uint256 claimedAmount_ = args_.amount - claimFeeAmount_;
+
+    // Transfer the remaining amount to the receiver
+    args_.rewardAsset.safeTransfer(args_.receiver, claimedAmount_);
+
     emit ClaimedRewards(
-      args_.stakePoolId, args_.rewardPoolId, args_.rewardAsset, args_.amount, args_.owner, args_.receiver
+      args_.stakePoolId, args_.rewardPoolId, args_.rewardAsset, claimedAmount_, args_.owner, args_.receiver
     );
   }
 
@@ -259,6 +272,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     uint256 stkReceiptTokenSupply_ = stkReceiptToken_.totalSupply();
     uint256 ownerStkReceiptTokenBalance_ = stkReceiptToken_.balanceOf(owner_);
     uint256 rewardsWeight_ = stakePool_.rewardsWeight;
+    uint16 claimFee_ = cozyManager.getClaimFee(IRewardsManager(address(this)));
 
     // Compute preview user accrued rewards accounting for any pending rewards drips.
     PreviewClaimableRewardsData[] memory claimableRewardsData_ =
@@ -275,15 +289,19 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
         stkReceiptTokenSupply_,
         rewardsWeight_
       );
+
+      uint256 accruedRewards_ = i < numUserRewardAssets_
+        ? _previewUpdateUserRewardsData(
+          ownerStkReceiptTokenBalance_, previewNextClaimableRewardsData_.indexSnapshot, userRewards_[i]
+        ).accruedRewards
+        : _previewAddUserRewardsData(ownerStkReceiptTokenBalance_, previewNextClaimableRewardsData_.indexSnapshot)
+          .accruedRewards;
+      uint256 claimedRewardsAmount_ = accruedRewards_ - _computeClaimFeeAmount(accruedRewards_, claimFee_);
+
       claimableRewardsData_[i] = PreviewClaimableRewardsData({
         rewardPoolId: i,
         asset: nextRewardDrips_[i].rewardAsset,
-        amount: i < numUserRewardAssets_
-          ? _previewUpdateUserRewardsData(
-            ownerStkReceiptTokenBalance_, previewNextClaimableRewardsData_.indexSnapshot, userRewards_[i]
-          ).accruedRewards
-          : _previewAddUserRewardsData(ownerStkReceiptTokenBalance_, previewNextClaimableRewardsData_.indexSnapshot)
-            .accruedRewards
+        amount: claimedRewardsAmount_
       });
     }
 
@@ -405,5 +423,9 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
   ) internal pure returns (uint256) {
     // Round down, in favor of leaving assets in the rewards pool.
     return stkReceiptTokenAmount_.mulDivDown(newRewardPoolIndex - oldRewardPoolIndex, MathConstants.WAD ** 2);
+  }
+
+  function _computeClaimFeeAmount(uint256 claimAmount_, uint16 claimFee_) internal pure returns (uint256) {
+    return claimAmount_.mulDivUp(claimFee_, MathConstants.ZOC);
   }
 }

--- a/src/lib/RewardsManagerBaseStorage.sol
+++ b/src/lib/RewardsManagerBaseStorage.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {IReceiptTokenFactory} from "cozy-safety-module-shared/interfaces/IReceiptTokenFactory.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {IReceiptTokenFactory} from "cozy-safety-module-libs/interfaces/IReceiptTokenFactory.sol";
 import {RewardsManagerState} from "./RewardsManagerStates.sol";
 import {ICozyManager} from "../interfaces/ICozyManager.sol";
 import {AssetPool, StakePool, IdLookup, RewardPool} from "./structs/Pools.sol";

--- a/src/lib/RewardsManagerCommon.sol
+++ b/src/lib/RewardsManagerCommon.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {RewardsManagerBaseStorage} from "./RewardsManagerBaseStorage.sol";
 import {ClaimRewardsArgs, ClaimableRewardsData, UserRewardsData} from "./structs/Rewards.sol";
 import {StakePool, RewardPool} from "./structs/Pools.sol";

--- a/src/lib/Staker.sol
+++ b/src/lib/Staker.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {SafeERC20} from "cozy-safety-module-shared/lib/SafeERC20.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {SafeERC20} from "cozy-safety-module-libs/lib/SafeERC20.sol";
 import {RewardsManagerState} from "./RewardsManagerStates.sol";
 import {AssetPool, StakePool} from "./structs/Pools.sol";
 import {ClaimRewardsArgs, ClaimableRewardsData} from "./structs/Rewards.sol";

--- a/src/lib/StateChanger.sol
+++ b/src/lib/StateChanger.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {Governable} from "cozy-safety-module-shared/lib/Governable.sol";
+import {Governable} from "cozy-safety-module-libs/lib/Governable.sol";
 import {IStateChangerEvents} from "../interfaces/IStateChangerEvents.sol";
 import {RewardsManagerState} from "./RewardsManagerStates.sol";
 import {RewardsManagerCommon} from "./RewardsManagerCommon.sol";

--- a/src/lib/structs/Configs.sol
+++ b/src/lib/structs/Configs.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 
 struct RewardPoolConfig {
   // The underlying asset of the reward pool.

--- a/src/lib/structs/Pools.sol
+++ b/src/lib/structs/Pools.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
 
 struct AssetPool {
   // The total balance of assets held by a rewards manager. This should be equivalent to asset.balanceOf(address(this)),

--- a/src/lib/structs/Rewards.sol
+++ b/src/lib/structs/Rewards.sol
@@ -43,6 +43,8 @@ struct PreviewClaimableRewardsData {
   uint16 rewardPoolId;
   // The amount of claimable rewards.
   uint256 amount;
+  // The claim fee amount.
+  uint256 claimFeeAmount;
   // The reward asset.
   IERC20 asset;
 }

--- a/src/lib/structs/Rewards.sol
+++ b/src/lib/structs/Rewards.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 
 // Used to track the rewards a user is entitled to for a given (stake pool, reward pool) pair.
 struct UserRewardsData {

--- a/test/Configurator.t.sol
+++ b/test/Configurator.t.sol
@@ -24,7 +24,6 @@ import {IConfiguratorEvents} from "../src/interfaces/IConfiguratorEvents.sol";
 import {IConfiguratorErrors} from "../src/interfaces/IConfiguratorErrors.sol";
 import {MockDripModel} from "./utils/MockDripModel.sol";
 import {MockERC20} from "./utils/MockERC20.sol";
-import {MockManager} from "./utils/MockManager.sol";
 import {TestBase} from "./utils/TestBase.sol";
 import "./utils/Stub.sol";
 

--- a/test/Configurator.t.sol
+++ b/test/Configurator.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {ReceiptToken} from "cozy-safety-module-shared/ReceiptToken.sol";
-import {ReceiptTokenFactory} from "cozy-safety-module-shared/ReceiptTokenFactory.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {Ownable} from "cozy-safety-module-shared/lib/Ownable.sol";
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {IReceiptTokenFactory} from "cozy-safety-module-shared/interfaces/IReceiptTokenFactory.sol";
+import {ReceiptToken} from "cozy-safety-module-libs/ReceiptToken.sol";
+import {ReceiptTokenFactory} from "cozy-safety-module-libs/ReceiptTokenFactory.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {Ownable} from "cozy-safety-module-libs/lib/Ownable.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {IReceiptTokenFactory} from "cozy-safety-module-libs/interfaces/IReceiptTokenFactory.sol";
 import {RewardPoolConfig, StakePoolConfig} from "../src/lib/structs/Configs.sol";
 import {StakePool, RewardPool, IdLookup} from "../src/lib/structs/Pools.sol";
 import {ClaimRewardsArgs, ClaimableRewardsData, UserRewardsData} from "../src/lib/structs/Rewards.sol";

--- a/test/CozyManager.t.sol
+++ b/test/CozyManager.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {Ownable} from "cozy-safety-module-shared/lib/Ownable.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {Ownable} from "cozy-safety-module-libs/lib/Ownable.sol";
 import {StakePoolConfig, RewardPoolConfig} from "../src/lib/structs/Configs.sol";
 import {CozyManager} from "../src/CozyManager.sol";
 import {RewardsManager} from "../src/RewardsManager.sol";

--- a/test/CozyManager.t.sol
+++ b/test/CozyManager.t.sol
@@ -149,6 +149,15 @@ contract CozyManagerUpdateClaimFees is MockDeployProtocol, CozyManagerTestSetup 
     cozyManager.updateClaimFee(newClaimFee_);
   }
 
+  function test_updateOverrideClaimFee_revertInvalidClaimFee() public {
+    uint16 claimFee_ = uint16(bound(_randomUint16(), MathConstants.ZOC + 1, type(uint16).max));
+    IRewardsManager rewardsManager_ = IRewardsManager(_randomAddress());
+
+    vm.expectRevert(ICozyManagerEvents.InvalidClaimFee.selector);
+    vm.prank(owner);
+    cozyManager.updateOverrideClaimFee(rewardsManager_, claimFee_);
+  }
+
   function test_updateOverrideClaimFee_revertNonOwnerAddress() public {
     uint16 newClaimFee_ = uint16(bound(_randomUint16(), 0, MathConstants.ZOC));
     IRewardsManager rewardsManager_ = IRewardsManager(_randomAddress());
@@ -217,7 +226,7 @@ contract CozyManagerUpdateClaimFees is MockDeployProtocol, CozyManagerTestSetup 
   {
     vm.assume(rewardsManagerAddress_ != otherRewardsManagerAddress_);
 
-    uint16 newClaimFee_ = uint16(bound(claimFee_, 0, MathConstants.ZOC));
+    claimFee_ = uint16(bound(claimFee_, 0, MathConstants.ZOC));
     IRewardsManager rewardsManager_ = IRewardsManager(rewardsManagerAddress_);
     IRewardsManager otherRewardsManager_ = IRewardsManager(otherRewardsManagerAddress_);
 

--- a/test/Depositor.t.sol
+++ b/test/Depositor.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {IDepositorErrors} from "../src/interfaces/IDepositorErrors.sol";
 import {Depositor} from "../src/lib/Depositor.sol";

--- a/test/DripModelIntegration.t.sol
+++ b/test/DripModelIntegration.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.22;
 
 import {DripModelConstant} from "cozy-safety-module-models/DripModelConstant.sol";
 import {DripModelExponential} from "cozy-safety-module-models/DripModelExponential.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {StakePoolConfig, RewardPoolConfig} from "../src/lib/structs/Configs.sol";
 import {RewardsManager} from "../src/RewardsManager.sol";
 import {IRewardsManager} from "../src/interfaces/IRewardsManager.sol";

--- a/test/DripModelIntegration.t.sol
+++ b/test/DripModelIntegration.t.sol
@@ -96,12 +96,16 @@ contract RewardsDripModelExponentialIntegrationTest is DripModelIntegrationTestS
 
   function test_RewardsDrip50Percent() public {
     uint256[] memory expectedClaimedRewards_ = new uint256[](6);
-    expectedClaimedRewards_[0] = 249; // 1000 * dripFactor(1 year) ~= 1000 * 0.25 ~= 249 (up to rounding down in favor
-      // the protocol)
-    expectedClaimedRewards_[1] = 132; // 1000 * dripFactor(0.5 years) ~= 1000 * 0.13397459686 ~= 132
-    expectedClaimedRewards_[2] = 68; // 1000 * dripFactor(0.25 years) ~= 1000 * 0.06939514124 ~= 68
-    expectedClaimedRewards_[3] = 27; // 1000 * dripFactor(0.1 years) ~= 1000 * 0.02835834225 ~= 27
-    expectedClaimedRewards_[4] = 13; // 1000 * dripFactor(0.05 years) ~= 1000 * 0.0142811467 ~= 13
+    expectedClaimedRewards_[0] = 246; // 1000 * dripFactor(1 year) ~= 1000 * 0.25 ~= 249 (up to rounding down in favor
+      // the protocol), taking a 1% fee, we get 249 * 0.99 = 246
+    expectedClaimedRewards_[1] = 130; // 1000 * dripFactor(0.5 years) ~= 1000 * 0.13397459686 ~= 132, taking a 1% fee,
+      // we get 132 * 0.99 = 130
+    expectedClaimedRewards_[2] = 67; // 1000 * dripFactor(0.25 years) ~= 1000 * 0.06939514124 ~= 68, taking a 1% fee, we
+      // get 68 * 0.99 = 67
+    expectedClaimedRewards_[3] = 26; // 1000 * dripFactor(0.1 years) ~= 1000 * 0.02835834225 ~= 27, taking a 1% fee, we
+      // get 27 * 0.99 = 26
+    expectedClaimedRewards_[4] = 12; // 1000 * dripFactor(0.05 years) ~= 1000 * 0.0142811467 ~= 13, taking a 1% fee, we
+      // get 13 * 0.99 = 13
     expectedClaimedRewards_[5] = 0; // 1000 * dripFactor(0) ~= 1000 * 0 ~= 0
     _testSeveralRewardsDrips(DEFAULT_DRIP_RATE, expectedClaimedRewards_);
   }
@@ -119,12 +123,16 @@ contract RewardsDripModelExponentialIntegrationTest is DripModelIntegrationTestS
 
   function test_RewardsDrip100Percent() public {
     uint256[] memory expectedClaimedRewards_ = new uint256[](6);
-    expectedClaimedRewards_[0] = 999; // 1000 * dripFactor(1 year) = 1000 * 1 ~= 999 (up to rounding down in favor
-      // the protocol)
-    expectedClaimedRewards_[1] = 999; // 1000 * dripFactor(0.5 years) = 1000 * 1 ~= 999
-    expectedClaimedRewards_[2] = 999; // 1000 * dripFactor(0.25 years) = 1000 * 1 ~= 999
-    expectedClaimedRewards_[3] = 999; // 1000 * dripFactor(0.1 years) = 1000 * 1 ~= 999
-    expectedClaimedRewards_[4] = 999; // 1000 * dripFactor(0.05 years) = 1000 * 1 ~= 999
+    expectedClaimedRewards_[0] = 989; // 1000 * dripFactor(1 year) = 1000 * 1 ~= 999 (up to rounding down in favor the
+      // protocol), taking a 1% fee, we get 999 * 0.99 = 989
+    expectedClaimedRewards_[1] = 989; // 1000 * dripFactor(0.5 years) = 1000 * 1 ~= 999, taking a 1% fee, we get 999 *
+      // 0.99 = 989
+    expectedClaimedRewards_[2] = 989; // 1000 * dripFactor(0.25 years) = 1000 * 1 ~= 999, taking a 1% fee, we get 999 *
+      // 0.99 = 989
+    expectedClaimedRewards_[3] = 989; // 1000 * dripFactor(0.1 years) = 1000 * 1 ~= 999, taking a 1% fee, we get 999 *
+      // 0.99 = 989
+    expectedClaimedRewards_[4] = 989; // 1000 * dripFactor(0.05 years) = 1000 * 1 ~= 999, taking a 1% fee, we get 999 *
+      // 0.99 = 989
     expectedClaimedRewards_[5] = 0; // 1000 * dripFactor(0) ~= 1000 * 0 ~= 0
     _testSeveralRewardsDrips(MathConstants.WAD, expectedClaimedRewards_);
   }
@@ -174,12 +182,16 @@ contract RewardsDripModelConstantIntegrationTest is DripModelIntegrationTestSetu
 
   function test_FeesDripOnePercent() public {
     uint256[] memory expectedClaimedRewards_ = new uint256[](6);
-    expectedClaimedRewards_[0] = 999; // 1000 * dripFactor(100 seconds) ~= 1000 * 1 ~= 999 (up to rounding down in favor
-      // the protocol)
-    expectedClaimedRewards_[1] = 499; // 1000 * dripFactor(50 seconds) ~= 1000 * 0.5 ~= 499
-    expectedClaimedRewards_[2] = 249; // 1000 * dripFactor(25 seconds) ~= 1000 * 0.25 ~= 249
-    expectedClaimedRewards_[3] = 99; // 1000 * dripFactor(10 seconds) ~= 1000 * 0.1 ~= 99
-    expectedClaimedRewards_[4] = 49; // 1000 * dripFactor(5 seconds) ~= 1000 * 0.05 ~= 49
+    expectedClaimedRewards_[0] = 989; // 1000 * dripFactor(100 seconds) ~= 1000 * 1 ~= 999 (up to rounding down in favor
+      // the protocol), taking a 1% fee, we get 999 * 0.99 = 989
+    expectedClaimedRewards_[1] = 494; // 1000 * dripFactor(50 seconds) ~= 1000 * 0.5 ~= 499, taking a 1% fee, we get
+      // 499 * 0.99 = 499
+    expectedClaimedRewards_[2] = 246; // 1000 * dripFactor(25 seconds) ~= 1000 * 0.25 ~= 249, taking a 1% fee, we get
+      // 249 * 0.99 = 249
+    expectedClaimedRewards_[3] = 98; // 1000 * dripFactor(10 seconds) ~= 1000 * 0.1 ~= 99, taking a 1% fee, we get 99 *
+      // 0.99 = 99
+    expectedClaimedRewards_[4] = 48; // 1000 * dripFactor(5 seconds) ~= 1000 * 0.05 ~= 49, taking a 1% fee, we get 49 *
+      // 0.99 = 49
     expectedClaimedRewards_[5] = 0; // 1000 * dripFactor(0) ~= 1000 * 0 ~= 0
     _testSeveralRewardsDrips(10, expectedClaimedRewards_);
   }
@@ -197,12 +209,16 @@ contract RewardsDripModelConstantIntegrationTest is DripModelIntegrationTestSetu
 
   function test_FeesDrip100Percent() public {
     uint256[] memory expectedClaimedRewards_ = new uint256[](6);
-    expectedClaimedRewards_[0] = 999; // 1000 * dripFactor(100 seconds) ~= 1000 * 1 = 999 (up to rounding down in favor
-      // the protocol)
-    expectedClaimedRewards_[1] = 999; // 1000 * dripFactor(50 seconds) ~= 1000 * 1 = 999
-    expectedClaimedRewards_[2] = 999; // 1000 * dripFactor(25 seconds) ~= 1000 * 1 = 999
-    expectedClaimedRewards_[3] = 999; // 1000 * dripFactor(10 seconds) ~= 1000 * 1 = 999
-    expectedClaimedRewards_[4] = 999; // 1000 * dripFactor(5 seconds) ~= 1000 * 1 = 999
+    expectedClaimedRewards_[0] = 989; // 1000 * dripFactor(100 seconds) ~= 1000 * 1 = 999 (up to rounding down in favor
+      // the protocol), taking a 1% fee, we get 999 * 0.99 = 989
+    expectedClaimedRewards_[1] = 989; // 1000 * dripFactor(50 seconds) ~= 1000 * 1 = 999, taking a 1% fee, we get 999 *
+      // 0.99 = 989
+    expectedClaimedRewards_[2] = 989; // 1000 * dripFactor(25 seconds) ~= 1000 * 1 = 999, taking a 1% fee, we get 999 *
+      // 0.99 = 989
+    expectedClaimedRewards_[3] = 989; // 1000 * dripFactor(10 seconds) ~= 1000 * 1 = 999, taking a 1% fee, we get 999 *
+      // 0.99 = 989
+    expectedClaimedRewards_[4] = 989; // 1000 * dripFactor(5 seconds) ~= 1000 * 1 = 999, taking a 1% fee, we get 999 *
+      // 0.99 = 989
     expectedClaimedRewards_[5] = 0; // 1000 * dripFactor(0) = 1000 * 0 = 0
     _testSeveralRewardsDrips(REWARD_POOL_AMOUNT, expectedClaimedRewards_);
   }

--- a/test/RewardsDistributor.t.sol
+++ b/test/RewardsDistributor.t.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.22;
 
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {DripModelExponential} from "cozy-safety-module-models/DripModelExponential.sol";
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {Ownable} from "cozy-safety-module-shared/lib/Ownable.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {Ownable} from "cozy-safety-module-libs/lib/Ownable.sol";
 import {Depositor} from "../src/lib/Depositor.sol";
 import {RewardsDistributor} from "../src/lib/RewardsDistributor.sol";
 import {RewardsManagerInspector} from "../src/lib/RewardsManagerInspector.sol";

--- a/test/RewardsDistributor.t.sol
+++ b/test/RewardsDistributor.t.sol
@@ -634,10 +634,14 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
       new PreviewClaimableRewardsData[](rewardPools_.length);
     for (uint16 i = 0; i < rewardPools_.length; i++) {
       IERC20 asset_ = rewardPools_[i].asset;
-      expectedPreviewClaimableRewardsData_[i] =
-        PreviewClaimableRewardsData({rewardPoolId: i, amount: asset_.balanceOf(receiver_), asset: asset_});
+      expectedPreviewClaimableRewardsData_[i] = PreviewClaimableRewardsData({
+        rewardPoolId: i,
+        amount: asset_.balanceOf(receiver_),
+        claimFeeAmount: asset_.balanceOf(cozyManager.owner()),
+        asset: asset_
+      });
       expectedPreviewClaimableRewardsDataPool0_[i] =
-        PreviewClaimableRewardsData({rewardPoolId: i, amount: 0, asset: asset_});
+        PreviewClaimableRewardsData({rewardPoolId: i, amount: 0, claimFeeAmount: 0, asset: asset_});
     }
     expectedPreviewClaimableRewards_[0] =
       PreviewClaimableRewards({stakePoolId: stakePoolId_, claimableRewardsData: expectedPreviewClaimableRewardsData_});
@@ -677,6 +681,10 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
       // claim
     assertEq(previewClaimableRewards_[0].claimableRewardsData[1].amount, 73_500_000);
     assertEq(previewClaimableRewards_[0].claimableRewardsData[2].amount, 2909);
+
+    assertEq(previewClaimableRewards_[0].claimableRewardsData[0].claimFeeAmount, 6); // 300 * 0.02
+    assertEq(previewClaimableRewards_[0].claimableRewardsData[1].claimFeeAmount, 1_500_000); // 73_500_000 * 0.02
+    assertEq(previewClaimableRewards_[0].claimableRewardsData[2].claimFeeAmount, 60); // 2969 * 0.02
 
     // Rewards Manager becomes paused.
     component.mockRewardsManagerState(RewardsManagerState.PAUSED);

--- a/test/RewardsManagerFactory.t.sol
+++ b/test/RewardsManagerFactory.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {ReceiptToken} from "cozy-safety-module-shared/ReceiptToken.sol";
-import {ReceiptTokenFactory} from "cozy-safety-module-shared/ReceiptTokenFactory.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {SafetyModuleState} from "cozy-safety-module-shared/lib/SafetyModuleStates.sol";
+import {ReceiptToken} from "cozy-safety-module-libs/ReceiptToken.sol";
+import {ReceiptTokenFactory} from "cozy-safety-module-libs/ReceiptTokenFactory.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {SafetyModuleState} from "cozy-safety-module-libs/lib/SafetyModuleStates.sol";
 import {IConfiguratorErrors} from "../src/interfaces/IConfiguratorErrors.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {IReceiptTokenFactory} from "cozy-safety-module-shared/interfaces/IReceiptTokenFactory.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {IReceiptTokenFactory} from "cozy-safety-module-libs/interfaces/IReceiptTokenFactory.sol";
 import {StkReceiptToken} from "../src/StkReceiptToken.sol";
 import {StakePool, RewardPool} from "../src/lib/structs/Pools.sol";
 import {StakePoolConfig, RewardPoolConfig} from "../src/lib/structs/Configs.sol";

--- a/test/Staker.t.sol
+++ b/test/Staker.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {SafeCastLib} from "cozy-safety-module-shared/lib/SafeCastLib.sol";
-import {SafetyModuleState} from "cozy-safety-module-shared/lib/SafetyModuleStates.sol";
-import {SafeCastLib} from "cozy-safety-module-shared/lib/SafeCastLib.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {SafeCastLib} from "cozy-safety-module-libs/lib/SafeCastLib.sol";
+import {SafetyModuleState} from "cozy-safety-module-libs/lib/SafetyModuleStates.sol";
+import {SafeCastLib} from "cozy-safety-module-libs/lib/SafeCastLib.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {IDepositorErrors} from "../src/interfaces/IDepositorErrors.sol";
 import {Depositor} from "../src/lib/Depositor.sol";

--- a/test/Staker.t.sol
+++ b/test/Staker.t.sol
@@ -19,8 +19,10 @@ import {RewardsManagerState} from "../src/lib/RewardsManagerStates.sol";
 import {AssetPool, StakePool} from "../src/lib/structs/Pools.sol";
 import {RewardPool} from "../src/lib/structs/Pools.sol";
 import {ClaimableRewardsData} from "../src/lib/structs/Rewards.sol";
+import {ICozyManager} from "../src/interfaces/ICozyManager.sol";
 import {MockERC20} from "./utils/MockERC20.sol";
 import {MockDripModel} from "./utils/MockDripModel.sol";
+import {MockManager} from "./utils/MockManager.sol";
 import {TestBase} from "./utils/TestBase.sol";
 import "./utils/Stub.sol";
 import "forge-std/console2.sol";
@@ -32,7 +34,8 @@ contract StakerUnitTest is TestBase {
   MockERC20 mockAsset = new MockERC20("Mock Asset", "MOCK", 6);
   MockERC20 mockStakeAsset = new MockERC20("Mock Stake Asset", "MOCK Stake", 6);
   MockERC20 mockStkReceiptToken = new MockERC20("Mock Cozy Stake Receipt Token", "cozyStk", 6);
-  TestableStaker component = new TestableStaker();
+  MockManager cozyManager = new MockManager();
+  TestableStaker component = new TestableStaker(cozyManager);
   uint256 cumulativeDrippedRewards_ = 290e18;
   uint256 cumulativeClaimableRewards_ = 90e18;
   uint256 initialIndexSnapshot_ = 11;
@@ -620,7 +623,14 @@ contract StakerUnitTest is TestBase {
 contract TestableStaker is Staker, Depositor, RewardsDistributor, RewardsManagerInspector {
   using SafeCastLib for uint256;
 
+  constructor(MockManager manager_) {
+    cozyManager = ICozyManager(address(manager_));
+  }
+
   // -------- Mock setters --------
+  function setClaimFee(uint16 claimFee_) external {
+    MockManager(address(cozyManager)).setClaimFee(claimFee_);
+  }
 
   function mockAddStakePool(StakePool memory stakePool_) external {
     stakePools.push(stakePool_);

--- a/test/StateChanger.t.sol
+++ b/test/StateChanger.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {Ownable} from "cozy-safety-module-shared/lib/Ownable.sol";
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {Ownable} from "cozy-safety-module-libs/lib/Ownable.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {ICozyManager} from "../src/interfaces/ICozyManager.sol";
 import {IStateChangerEvents} from "../src/interfaces/IStateChangerEvents.sol";
 import {RewardPool, StakePool} from "../src/lib/structs/Pools.sol";

--- a/test/benchmarks/BenchmarkMaxPools.t.sol
+++ b/test/benchmarks/BenchmarkMaxPools.t.sol
@@ -229,11 +229,9 @@ abstract contract BenchmarkMaxPools is MockDeployProtocol {
   function test_updateConfigs() public {
     (StakePoolConfig[] memory stakePoolConfigs_, RewardPoolConfig[] memory rewardPoolConfigs_) = _setUpConfigUpdate();
 
-    vm.startPrank(owner);
     uint256 gasInitial_ = gasleft();
     rewardsManager.updateConfigs(stakePoolConfigs_, rewardPoolConfigs_);
     console2.log("Gas used for updateConfigs: %s", gasInitial_ - gasleft());
-    vm.stopPrank();
   }
 }
 

--- a/test/benchmarks/BenchmarkMaxPools.t.sol
+++ b/test/benchmarks/BenchmarkMaxPools.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
 import {DripModelExponential} from "cozy-safety-module-models/DripModelExponential.sol";
 import {RewardsManager} from "../../src/RewardsManager.sol";
 import {RewardPoolConfig, StakePoolConfig} from "../../src/lib/structs/Configs.sol";

--- a/test/invariants/AccountingInvariants.t.sol
+++ b/test/invariants/AccountingInvariants.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.22;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {StakePool, RewardPool} from "../../src/lib/structs/Pools.sol";
 import {
   InvariantTestBaseWithStateTransitions,

--- a/test/invariants/AccountingInvariants.t.sol
+++ b/test/invariants/AccountingInvariants.t.sol
@@ -57,6 +57,8 @@ abstract contract AccountingInvariantsWithStateTransitions is InvariantTestBaseW
       if (!ghostRewardsClaimedIncluded[rewardPool_.asset]) {
         accountingSums[rewardPool_.asset] -=
           rewardsManagerHandler.ghost_rewardsClaimed(IERC20(address(rewardPool_.asset)));
+        accountingSums[rewardPool_.asset] -=
+          rewardsManagerHandler.ghost_rewardsPaidAsFees(IERC20(address(rewardPool_.asset)));
         ghostRewardsClaimedIncluded[rewardPool_.asset] = true;
       }
     }

--- a/test/invariants/ConfiguratorInvariants.t.sol
+++ b/test/invariants/ConfiguratorInvariants.t.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.22;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {Ownable} from "cozy-safety-module-shared/lib/Ownable.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {Ownable} from "cozy-safety-module-libs/lib/Ownable.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {StakePool, RewardPool} from "../../src/lib/structs/Pools.sol";
 import {StakePoolConfig, RewardPoolConfig} from "../../src/lib/structs/Configs.sol";
 import {ClaimableRewardsData} from "../../src/lib/structs/Rewards.sol";

--- a/test/invariants/RewardsAccountingInvariants.t.sol
+++ b/test/invariants/RewardsAccountingInvariants.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.22;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
 import {StakePool, RewardPool} from "../../src/lib/structs/Pools.sol";
 import {ClaimableRewardsData, UserRewardsData} from "../../src/lib/structs/Rewards.sol";
 import {

--- a/test/invariants/RewardsDepositInvariants.t.sol
+++ b/test/invariants/RewardsDepositInvariants.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.22;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {AssetPool, RewardPool} from "../../src/lib/structs/Pools.sol";
 import {RewardsManagerState} from "../../src/lib/RewardsManagerStates.sol";

--- a/test/invariants/RewardsDistributorInvariants.t.sol
+++ b/test/invariants/RewardsDistributorInvariants.t.sol
@@ -367,7 +367,8 @@ abstract contract RewardsDistributorInvariantsWithStateTransitions is InvariantT
 
   function invariant_stkReceiptTokenTransferAccounting() public syncCurrentTimestamp(rewardsManagerHandler) {
     address to_ = _randomAddress();
-    (address from_, uint256 amount_) = rewardsManagerHandler.stkReceiptTokenTransfer(_randomUint64(), to_, _randomUint256());
+    (address from_, uint256 amount_) =
+      rewardsManagerHandler.stkReceiptTokenTransfer(_randomUint64(), to_, _randomUint256());
     if (from_ == rewardsManagerHandler.DEFAULT_ADDRESS()) return;
     if (amount_ == 0) return;
 

--- a/test/invariants/RewardsDistributorInvariants.t.sol
+++ b/test/invariants/RewardsDistributorInvariants.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.22;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {Ownable} from "cozy-safety-module-shared/lib/Ownable.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {Ownable} from "cozy-safety-module-libs/lib/Ownable.sol";
 import {StakePool, RewardPool} from "../../src/lib/structs/Pools.sol";
 import {ClaimableRewardsData, UserRewardsData, PreviewClaimableRewards} from "../../src/lib/structs/Rewards.sol";
 import {

--- a/test/invariants/StakerInvariants.t.sol
+++ b/test/invariants/StakerInvariants.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.22;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {AssetPool, StakePool} from "../../src/lib/structs/Pools.sol";
 import {IDepositorErrors} from "../../src/interfaces/IDepositorErrors.sol";

--- a/test/invariants/StateTransitionInvariants.t.sol
+++ b/test/invariants/StateTransitionInvariants.t.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.22;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {Ownable} from "cozy-safety-module-shared/lib/Ownable.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {Ownable} from "cozy-safety-module-libs/lib/Ownable.sol";
 import {StakePool, RewardPool, AssetPool} from "../../src/lib/structs/Pools.sol";
 import {ClaimableRewardsData, UserRewardsData, PreviewClaimableRewards} from "../../src/lib/structs/Rewards.sol";
 import {RewardsManagerState} from "../../src/lib/RewardsManagerStates.sol";

--- a/test/invariants/UnstakerInvariants.t.sol
+++ b/test/invariants/UnstakerInvariants.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.22;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
-import {ICommonErrors} from "cozy-safety-module-shared/interfaces/ICommonErrors.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
+import {ICommonErrors} from "cozy-safety-module-libs/interfaces/ICommonErrors.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
 import {StakePool, RewardPool, AssetPool} from "../../src/lib/structs/Pools.sol";
 import {ClaimableRewardsData, UserRewardsData, PreviewClaimableRewards} from "../../src/lib/structs/Rewards.sol";
 import {

--- a/test/invariants/handlers/RewardsManagerHandler.sol
+++ b/test/invariants/handlers/RewardsManagerHandler.sol
@@ -271,7 +271,7 @@ contract RewardsManagerHandler is TestBase {
     }
 
     uint256 boundedStkReceiptTokenTransferAmount_ =
-      bound(uint256(stkReceiptTokenTransferAmount_), 0, actorStkReceiptTokenBalance_);
+      bound(uint256(stkReceiptTokenTransferAmount_), 1, actorStkReceiptTokenBalance_);
 
     vm.startPrank(currentActor);
     // This will call `updateUserRewardsForStkReceiptTokenTransfer` in the RewardsManager.

--- a/test/invariants/handlers/RewardsManagerHandler.sol
+++ b/test/invariants/handlers/RewardsManagerHandler.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.22;
 import {console2} from "forge-std/console2.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {RewardsManager} from "../../../src/RewardsManager.sol";
 import {StakePool, RewardPool} from "../../../src/lib/structs/Pools.sol";
 import {PreviewClaimableRewards, PreviewClaimableRewardsData} from "../../../src/lib/structs/Rewards.sol";

--- a/test/invariants/utils/InvariantTestBase.sol
+++ b/test/invariants/utils/InvariantTestBase.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.22;
 
 import {DripModelExponential} from "cozy-safety-module-models/DripModelExponential.sol";
-import {MathConstants} from "cozy-safety-module-shared/lib/MathConstants.sol";
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {RewardsManager} from "../../../src/RewardsManager.sol";
 import {StakePoolConfig, RewardPoolConfig} from "../../../src/lib/structs/Configs.sol";
 import {IRewardsManager} from "../../../src/interfaces/IRewardsManager.sol";

--- a/test/invariants/utils/InvariantTestBase.sol
+++ b/test/invariants/utils/InvariantTestBase.sol
@@ -65,7 +65,8 @@ abstract contract InvariantTestBase is InvariantBaseDeploy {
   }
 
   function _initHandler() internal {
-    rewardsManagerHandler = new RewardsManagerHandler(rewardsManager, numStakePools, numRewardPools, block.timestamp);
+    rewardsManagerHandler =
+      new RewardsManagerHandler(rewardsManager, cozyManager, numStakePools, numRewardPools, block.timestamp);
     targetSelector(FuzzSelector({addr: address(rewardsManagerHandler), selectors: _fuzzedSelectors()}));
     targetContract(address(rewardsManagerHandler));
   }

--- a/test/utils/MockDeployProtocol.sol
+++ b/test/utils/MockDeployProtocol.sol
@@ -28,6 +28,7 @@ contract MockDeployer is TestBase {
 
   uint16 constant ALLOWED_STAKE_POOLS = 100;
   uint16 constant ALLOWED_REWARD_POOLS = 100;
+  uint16 constant DEFAULT_CLAIM_FEE = 100;
 
   function deployMockProtocol() public virtual {
     uint256 nonce_ = vm.getNonce(address(this));
@@ -56,7 +57,7 @@ contract MockDeployer is TestBase {
     depositReceiptTokenLogic.initialize(address(0), "", "", 0);
     stkReceiptTokenLogic.initialize(address(0), "", "", 0);
     receiptTokenFactory = new ReceiptTokenFactory(depositReceiptTokenLogic_, stkReceiptTokenLogic_);
-    cozyManager = new CozyManager(owner, pauser, rewardsManagerFactory);
+    cozyManager = new CozyManager(owner, pauser, rewardsManagerFactory, DEFAULT_CLAIM_FEE);
   }
 }
 

--- a/test/utils/MockDeployProtocol.sol
+++ b/test/utils/MockDeployProtocol.sol
@@ -23,7 +23,7 @@ contract MockDeployer is TestBase {
   IRewardsManager rewardsManagerLogic;
   ICozyManager cozyManager;
 
-  address owner = address(this);
+  address owner = address(0xABCD);
   address pauser = address(0xBEEF);
 
   uint16 constant ALLOWED_STAKE_POOLS = 100;

--- a/test/utils/MockDeployProtocol.sol
+++ b/test/utils/MockDeployProtocol.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.22;
 
 import {IRewardsManager} from "../../src/interfaces/IRewardsManager.sol";
 import {IRewardsManagerFactory} from "../../src/interfaces/IRewardsManagerFactory.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
-import {IReceiptTokenFactory} from "cozy-safety-module-shared/interfaces/IReceiptTokenFactory.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {IReceiptTokenFactory} from "cozy-safety-module-libs/interfaces/IReceiptTokenFactory.sol";
 import {CozyManager} from "../../src/CozyManager.sol";
-import {ReceiptToken} from "cozy-safety-module-shared/ReceiptToken.sol";
-import {ReceiptTokenFactory} from "cozy-safety-module-shared/ReceiptTokenFactory.sol";
+import {ReceiptToken} from "cozy-safety-module-libs/ReceiptToken.sol";
+import {ReceiptTokenFactory} from "cozy-safety-module-libs/ReceiptTokenFactory.sol";
 import {StkReceiptToken} from "../../src/StkReceiptToken.sol";
 import {StakePoolConfig, RewardPoolConfig} from "../../src/lib/structs/Configs.sol";
 import {RewardsManager} from "../../src/RewardsManager.sol";

--- a/test/utils/MockDripModel.sol
+++ b/test/utils/MockDripModel.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
 
 contract MockDripModel is IDripModel {
   uint256 public dripFactorConstant;

--- a/test/utils/MockERC20.sol
+++ b/test/utils/MockERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import "cozy-safety-module-shared/lib/ERC20.sol";
+import "cozy-safety-module-libs/lib/ERC20.sol";
 
 /// @author Solmate
 /// https://github.com/transmissions11/solmate/blob/d155ee8d58f96426f57c015b34dee8a410c1eacc/src/test/utils/mocks/MockERC20.sol

--- a/test/utils/MockManager.sol
+++ b/test/utils/MockManager.sol
@@ -2,10 +2,12 @@
 pragma solidity 0.8.22;
 
 import {Governable} from "cozy-safety-module-libs/lib/Governable.sol";
+import {IRewardsManager} from "../../src/interfaces/IRewardsManager.sol";
 
 contract MockManager is Governable {
   uint256 public allowedReservePools;
   uint256 public allowedRewardPools;
+  uint16 public claimFee;
 
   function initGovernable(address owner_, address pauser_) external {
     __initGovernable(owner_, pauser_);
@@ -21,5 +23,13 @@ contract MockManager is Governable {
 
   function setAllowedRewardPools(uint256 allowedRewardPools_) external {
     allowedRewardPools = allowedRewardPools_;
+  }
+
+  function setClaimFee(uint16 claimFee_) external {
+    claimFee = claimFee_;
+  }
+
+  function getClaimFee(IRewardsManager /* rewardsManager_ */ ) external view returns (uint16) {
+    return claimFee;
   }
 }

--- a/test/utils/MockManager.sol
+++ b/test/utils/MockManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {Governable} from "cozy-safety-module-shared/lib/Governable.sol";
+import {Governable} from "cozy-safety-module-libs/lib/Governable.sol";
 
 contract MockManager is Governable {
   uint256 public allowedReservePools;

--- a/test/utils/TestAssertions.sol
+++ b/test/utils/TestAssertions.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {SafetyModuleState} from "cozy-safety-module-shared/lib/SafetyModuleStates.sol";
+import {SafetyModuleState} from "cozy-safety-module-libs/lib/SafetyModuleStates.sol";
 import {RewardsManagerState} from "../../src/lib/RewardsManagerStates.sol";
 import {RewardPool, StakePool} from "../../src/lib/structs/Pools.sol";
 import {

--- a/test/utils/TestBase.sol
+++ b/test/utils/TestBase.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity 0.8.22;
 
-import {IDripModel} from "cozy-safety-module-shared/interfaces/IDripModel.sol";
-import {IERC20} from "cozy-safety-module-shared/interfaces/IERC20.sol";
-import {IReceiptToken} from "cozy-safety-module-shared/interfaces/IReceiptToken.sol";
+import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
 import {StakePoolConfig} from "../../src/lib/structs/Configs.sol";
 import {IRewardsManager} from "../../src/interfaces/IRewardsManager.sol";
 import {RewardPool, StakePool} from "../../src/lib/structs/Pools.sol";


### PR DESCRIPTION
- Adds the rewards manager claim fee
- Updates cozy-safety-module-shared dependency to cozy-safety-module-libs (its new name)
- Updates cozy-safety-module-models dependency
- Some fixes to old invariant tests and unit tests (note that updates to foundry changed how vm.expectRevert works so we added `allow_internal_expect_revert` to foundry.toml)