### PR TITLE
Add drip pre-withdraw eng-1622

### DIFF
--- a/src/interfaces/IRewardsManager.sol
+++ b/src/interfaces/IRewardsManager.sol
@@ -3,9 +3,13 @@ pragma solidity ^0.8.0;
 
 import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {StakePool, RewardPool, AssetPool} from "../lib/structs/Pools.sol";
-import {ClaimableRewardsData, PreviewClaimableRewards, UserRewardsData} from "../lib/structs/Rewards.sol";
+import {
+  ClaimableRewardsData,
+  PreviewClaimableRewards,
+  UserRewardsData,
+  DepositorRewardsData
+} from "../lib/structs/Rewards.sol";
 import {RewardsManagerState} from "../lib/RewardsManagerStates.sol";
-import {ClaimableRewardsData, PreviewClaimableRewards} from "../lib/structs/Rewards.sol";
 import {RewardPoolConfig, StakePoolConfig} from "../lib/structs/Configs.sol";
 import {ICozyManager} from "./ICozyManager.sol";
 
@@ -36,6 +40,11 @@ interface IRewardsManager {
   function getClaimableRewards() external view returns (ClaimableRewardsData[][] memory);
 
   function getClaimableRewards(uint16 stakePoolId_) external view returns (ClaimableRewardsData[] memory);
+
+  function getDepositorRewards(uint16 rewardPoolId_, address depositor_)
+    external
+    view
+    returns (DepositorRewardsData memory);
 
   function getRewardPools() external view returns (RewardPool[] memory);
 

--- a/src/interfaces/IWithdrawerErrors.sol
+++ b/src/interfaces/IWithdrawerErrors.sol
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
-
-interface IWithdrawerErrors {
-  /// @notice Thrown when attempting an invalid withdraw.
-  error InvalidWithdraw();
-}

--- a/src/lib/RewardsDistributor.sol
+++ b/src/lib/RewardsDistributor.sol
@@ -340,6 +340,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
   function _getNextDripFactor(uint256 totalBaseAmount_, IDripModel dripModel_, uint256 lastDripTime_)
     internal
     view
+    override
     returns (uint256)
   {
     if (rewardsManagerState == RewardsManagerState.PAUSED) return 0;

--- a/src/lib/RewardsManagerCommon.sol
+++ b/src/lib/RewardsManagerCommon.sol
@@ -37,6 +37,14 @@ abstract contract RewardsManagerCommon is RewardsManagerBaseStorage, ICommonErro
     virtual
     returns (uint256);
 
+  /// @notice Returns the next drip factor given a base amount, drip model and last drip time.
+  /// @dev Defined in RewardsDistributor.
+  function _getNextDripFactor(uint256 totalBaseAmount_, IDripModel dripModel_, uint256 lastDripTime_)
+    internal
+    view
+    virtual
+    returns (uint256);
+
   /// @dev Defined in RewardsDistributor.
   function _updateUserRewards(
     uint256 userStkReceiptTokenBalance_,

--- a/src/lib/RewardsManagerInspector.sol
+++ b/src/lib/RewardsManagerInspector.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.22;
 
 import {RewardsManagerCommon} from "./RewardsManagerCommon.sol";
 import {StakePool, RewardPool} from "./structs/Pools.sol";
-import {ClaimableRewardsData, UserRewardsData} from "./structs/Rewards.sol";
+import {ClaimableRewardsData, UserRewardsData, DepositorRewardsData} from "./structs/Rewards.sol";
 
 abstract contract RewardsManagerInspector is RewardsManagerCommon {
   uint256 internal constant POOL_AMOUNT_FLOOR = 1;
@@ -26,6 +26,18 @@ abstract contract RewardsManagerInspector is RewardsManagerCommon {
   /// @return userRewards_ The array of user rewards data.
   function getUserRewards(uint16 stakePoolId_, address user) external view returns (UserRewardsData[] memory) {
     return userRewards[stakePoolId_][user];
+  }
+
+  /// @notice Returns the depositor rewards for a reward pool.
+  /// @param rewardPoolId_ The ID of the reward pool.
+  /// @param depositor_ The depositor's address.
+  /// @return depositorRewards_ The depositor rewards data.
+  function getDepositorRewards(uint16 rewardPoolId_, address depositor_)
+    external
+    view
+    returns (DepositorRewardsData memory)
+  {
+    return depositorRewards[rewardPoolId_][depositor_];
   }
 
   /// @notice Returns all claimable rewards for all stake pools and reward pools.

--- a/src/lib/Withdrawer.sol
+++ b/src/lib/Withdrawer.sol
@@ -4,17 +4,15 @@ pragma solidity 0.8.22;
 import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {SafeERC20} from "cozy-safety-module-libs/lib/SafeERC20.sol";
 import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
-
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {RewardPool} from "./structs/Pools.sol";
 import {DepositorRewardsData} from "./structs/Rewards.sol";
 import {RewardsManagerCommon} from "./RewardsManagerCommon.sol";
 import {RewardsMathLib} from "./RewardsMathLib.sol";
 import {RewardsManagerState} from "./RewardsManagerStates.sol";
-import {IWithdrawerErrors} from "../interfaces/IWithdrawerErrors.sol";
 import {IWithdrawerEvents} from "../interfaces/IWithdrawerEvents.sol";
 
-abstract contract Withdrawer is RewardsManagerCommon, IWithdrawerErrors, IWithdrawerEvents {
+abstract contract Withdrawer is RewardsManagerCommon, IWithdrawerEvents {
   using SafeERC20 for IERC20;
   using FixedPointMathLib for uint256;
 

--- a/src/lib/Withdrawer.sol
+++ b/src/lib/Withdrawer.sol
@@ -3,11 +3,14 @@ pragma solidity 0.8.22;
 
 import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {SafeERC20} from "cozy-safety-module-libs/lib/SafeERC20.sol";
+import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
+
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {RewardPool} from "./structs/Pools.sol";
 import {DepositorRewardsData} from "./structs/Rewards.sol";
 import {RewardsManagerCommon} from "./RewardsManagerCommon.sol";
 import {RewardsMathLib} from "./RewardsMathLib.sol";
+import {RewardsManagerState} from "./RewardsManagerStates.sol";
 import {IWithdrawerErrors} from "../interfaces/IWithdrawerErrors.sol";
 import {IWithdrawerEvents} from "../interfaces/IWithdrawerEvents.sol";
 
@@ -17,14 +20,18 @@ abstract contract Withdrawer is RewardsManagerCommon, IWithdrawerErrors, IWithdr
 
   /// @notice Withdraw undripped reward assets.
   /// @param rewardPoolId_ The ID of the reward pool to withdraw from.
-  /// @param rewardAssetAmount_ The amount of reward assets to withdraw.
+  /// @param rewardAssetAmount_ The maximum amount of reward assets to withdraw. If type(uint256).max, all withdrawable
+  /// rewards will be withdrawn. Else, up to `rewardAssetAmount_` of withdrawable rewards will be withdrawn.
   /// @param receiver_ The address that will receive the withdrawn assets.
   function withdrawRewardAssets(uint16 rewardPoolId_, uint256 rewardAssetAmount_, address receiver_) external {
     RewardPool storage rewardPool_ = rewardPools[rewardPoolId_];
+    if (rewardsManagerState != RewardsManagerState.PAUSED) _dripRewardPool(rewardPool_);
 
     uint256 currentWithdrawableRewards_ =
       _previewCurrentWithdrawableRewards(rewardPool_, depositorRewards[rewardPoolId_][msg.sender]);
-    if (rewardAssetAmount_ > currentWithdrawableRewards_) revert InvalidWithdraw();
+    rewardAssetAmount_ = rewardAssetAmount_ == type(uint256).max
+      ? currentWithdrawableRewards_
+      : (rewardAssetAmount_ < currentWithdrawableRewards_ ? rewardAssetAmount_ : currentWithdrawableRewards_);
 
     depositorRewards[rewardPoolId_][msg.sender] = DepositorRewardsData({
       withdrawableRewards: currentWithdrawableRewards_ - rewardAssetAmount_,
@@ -51,19 +58,44 @@ abstract contract Withdrawer is RewardsManagerCommon, IWithdrawerErrors, IWithdr
     RewardPool storage rewardPool_,
     DepositorRewardsData storage depositorRewardsData_
   ) internal view override returns (uint256) {
-    if (depositorRewardsData_.epoch < rewardPool_.epoch || depositorRewardsData_.withdrawableRewards == 0) {
+    (uint256 nextRewardPoolEpoch_, uint256 nextRewardPoolLogIndexSnapshot_) =
+      _getNextRewardPoolEpochAndLogIndexSnapshot(rewardPool_);
+
+    if (depositorRewardsData_.epoch < nextRewardPoolEpoch_ || depositorRewardsData_.withdrawableRewards == 0) {
       // Rewards have fully dripped or the depositor previously had no withdrawable rewards, so the depositor has no
       // withdrawable rewards.
       return 0;
-    } else if (depositorRewardsData_.logIndexSnapshot == rewardPool_.logIndexSnapshot) {
+    } else if (depositorRewardsData_.logIndexSnapshot == nextRewardPoolLogIndexSnapshot_) {
       // Rewards have not dripped since the last update, so no update to the depositor's withdrawable rewards.
       return depositorRewardsData_.withdrawableRewards;
     } else {
       // Rewards have dripped since the last update, so scale down the depositor's withdrawable rewards by the amount of
       // drip.
       return depositorRewardsData_.withdrawableRewards.mulWadDown(
-        RewardsMathLib.expNeg(rewardPool_.logIndexSnapshot - depositorRewardsData_.logIndexSnapshot)
+        RewardsMathLib.expNeg(nextRewardPoolLogIndexSnapshot_ - depositorRewardsData_.logIndexSnapshot)
       );
+    }
+  }
+
+  function _getNextRewardPoolEpochAndLogIndexSnapshot(RewardPool storage rewardPool_)
+    internal
+    view
+    returns (uint256 nextRewardPoolEpoch_, uint256 nextRewardPoolLogIndexSnapshot_)
+  {
+    nextRewardPoolEpoch_ = rewardPool_.epoch;
+    nextRewardPoolLogIndexSnapshot_ = rewardPool_.logIndexSnapshot;
+
+    if (rewardPool_.lastDripTime != block.timestamp) {
+      uint256 nextDripFactor_ =
+        _getNextDripFactor(rewardPool_.undrippedRewards, rewardPool_.dripModel, rewardPool_.lastDripTime);
+
+      if (nextDripFactor_ == MathConstants.WAD) {
+        // Full drip, so increment epoch and reset log index
+        nextRewardPoolEpoch_ += 1;
+        nextRewardPoolLogIndexSnapshot_ = 0;
+      } else {
+        nextRewardPoolLogIndexSnapshot_ += RewardsMathLib.negLn(MathConstants.WAD - nextDripFactor_);
+      }
     }
   }
 }

--- a/test/Configurator.t.sol
+++ b/test/Configurator.t.sol
@@ -779,6 +779,15 @@ contract TestableConfigurator is Configurator, RewardsManagerInspector, Testable
     __readStub__();
   }
 
+  function _getNextDripFactor(uint256, /* totalBaseAmount_ */ IDripModel, /* dripModel_ */ uint256 /*lastDripTime_*/ )
+    internal
+    view
+    override
+    returns (uint256)
+  {
+    __readStub__();
+  }
+
   function _updateUserRewards(
     uint256, /*userStkReceiptTokenBalance_*/
     mapping(uint16 => ClaimableRewardsData) storage, /*claimableRewards_*/

--- a/test/Depositor.t.sol
+++ b/test/Depositor.t.sol
@@ -418,6 +418,15 @@ contract TestableDepositor is Withdrawer, Depositor, RewardsManagerInspector {
       : mockNextRewardsDripAmount;
   }
 
+  function _getNextDripFactor(uint256, /* totalBaseAmount_ */ IDripModel, /* dripModel_ */ uint256 /*lastDripTime_*/ )
+    internal
+    view
+    override
+    returns (uint256)
+  {
+    __readStub__();
+  }
+
   function _updateUserRewards(
     uint256, /*userStkReceiptTokenBalance_*/
     mapping(uint16 => ClaimableRewardsData) storage, /*claimableRewards_*/

--- a/test/StateChanger.t.sol
+++ b/test/StateChanger.t.sol
@@ -236,6 +236,15 @@ contract TestableStateChanger is StateChanger, StateChangerTestMockEvents {
     __readStub__();
   }
 
+  function _getNextDripFactor(uint256, /* totalBaseAmount_ */ IDripModel, /* dripModel_ */ uint256 /*lastDripTime_*/ )
+    internal
+    view
+    override
+    returns (uint256)
+  {
+    __readStub__();
+  }
+
   function _updateUserRewards(
     uint256, /*userStkReceiptTokenBalance_*/
     mapping(uint16 => ClaimableRewardsData) storage, /*claimableRewards_*/

--- a/test/Withdrawer.t.sol
+++ b/test/Withdrawer.t.sol
@@ -179,6 +179,49 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     );
   }
 
+  function test_withdrawAutoDrips() public {
+    address depositor_ = _randomAddress();
+    uint256 depositAmount_ = 100e18;
+
+    _depositRewardAssets(depositor_, depositAmount_);
+
+    uint256 warpTime_ = block.timestamp + 1;
+    vm.warp(warpTime_);
+
+    // Set up a 50% drip but do not manually drip before withdrawal.
+    flexibleDripModel.setNextDripFactor(0.5e18);
+
+    // Withdrawable rewards should still reflect the full deposit before withdrawing.
+    uint256 expectedWithdraw_ = depositAmount_.mulWadDown(MathConstants.WAD - 0.5e18);
+    uint256 expectedDrippedRewards_ = depositAmount_.mulWadDown(0.5e18);
+    assertApproxEqRel(
+      rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, depositor_),
+      expectedWithdraw_,
+      0.001e18,
+      "Withdrawable should not change before auto drip"
+    );
+
+    uint256 previewWithdrawable_ = rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, depositor_);
+
+    _expectEmit();
+    emit IWithdrawerEvents.Withdrawn(depositor_, DEFAULT_REWARD_POOL_ID, previewWithdrawable_, depositor_);
+    vm.prank(depositor_);
+    rewardsManager.withdrawRewardAssets(DEFAULT_REWARD_POOL_ID, type(uint256).max, depositor_);
+
+    assertEq(rewardAsset.balanceOf(depositor_), previewWithdrawable_);
+    assertEq(
+      rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, depositor_),
+      0,
+      "Depositor should have no withdrawable rewards"
+    );
+
+    RewardPool memory pool_ = getRewardPool(rewardsManager, DEFAULT_REWARD_POOL_ID);
+    assertEq(pool_.undrippedRewards, depositAmount_ - previewWithdrawable_ - expectedDrippedRewards_);
+    assertEq(pool_.cumulativeDrippedRewards, expectedDrippedRewards_);
+    assertEq(pool_.lastDripTime, warpTime_);
+    assertGt(pool_.logIndexSnapshot, 0);
+  }
+
   function test_withdrawMultipleDripsCompound() public {
     address depositor_ = _randomAddress();
     uint256 depositAmount_ = 1000e18;

--- a/test/Withdrawer.t.sol
+++ b/test/Withdrawer.t.sol
@@ -10,6 +10,8 @@ import {IRewardsManager} from "../src/interfaces/IRewardsManager.sol";
 import {AssetPool, StakePool, RewardPool} from "../src/lib/structs/Pools.sol";
 import {StakePoolConfig, RewardPoolConfig} from "../src/lib/structs/Configs.sol";
 import {DepositorRewardsData} from "../src/lib/structs/Rewards.sol";
+import {RewardsMathLib} from "../src/lib/RewardsMathLib.sol";
+import {RewardsManagerState} from "../src/lib/RewardsManagerStates.sol";
 import {RewardsManager} from "../src/RewardsManager.sol";
 import {MockERC20} from "./utils/MockERC20.sol";
 import {MockDripModelFlexible} from "./utils/MockDripModelFlexible.sol";
@@ -220,6 +222,48 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     assertEq(pool_.cumulativeDrippedRewards, expectedDrippedRewards_);
     assertEq(pool_.lastDripTime, warpTime_);
     assertGt(pool_.logIndexSnapshot, 0);
+  }
+
+  function test_withdrawZeroAmountStillDrips() public {
+    address depositor_ = _randomAddress();
+    uint256 depositAmount_ = 200e18;
+
+    _depositRewardAssets(depositor_, depositAmount_);
+
+    uint256 warpTime_ = block.timestamp + 1;
+    vm.warp(warpTime_);
+    flexibleDripModel.setNextDripFactor(0.4e18);
+
+    vm.prank(depositor_);
+    rewardsManager.withdrawRewardAssets(DEFAULT_REWARD_POOL_ID, 0, depositor_);
+
+    uint256 expectedWithdrawable_ = depositAmount_.mulWadDown(MathConstants.WAD - 0.4e18);
+    uint256 expectedDrip_ = depositAmount_ - expectedWithdrawable_;
+
+    RewardPool memory pool_ = getRewardPool(rewardsManager, DEFAULT_REWARD_POOL_ID);
+    assertEq(pool_.lastDripTime, uint128(warpTime_));
+    assertEq(pool_.cumulativeDrippedRewards, expectedDrip_);
+    assertEq(pool_.undrippedRewards, expectedWithdrawable_);
+    assertEq(pool_.epoch, 0);
+    assertEq(pool_.logIndexSnapshot, RewardsMathLib.negLn(MathConstants.WAD - 0.4e18));
+
+    DepositorRewardsData memory depositorData_ =
+      RewardsManager(address(rewardsManager)).getDepositorRewards(DEFAULT_REWARD_POOL_ID, depositor_);
+    assertLe(depositorData_.withdrawableRewards, expectedWithdrawable_);
+    assertApproxEqRel(depositorData_.withdrawableRewards, expectedWithdrawable_, 0.01e18);
+    assertEq(depositorData_.logIndexSnapshot, pool_.logIndexSnapshot);
+    assertEq(depositorData_.epoch, pool_.epoch);
+
+    assertEq(rewardAsset.balanceOf(depositor_), 0);
+    assertLe(
+      rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, depositor_), expectedWithdrawable_
+    );
+    assertApproxEqRel(
+      rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, depositor_),
+      expectedWithdrawable_,
+      0.01e18
+    );
+    assertEq(rewardsManager.assetPools(IERC20(address(rewardAsset))).amount, depositAmount_);
   }
 
   function test_withdrawMultipleDripsCompound() public {

--- a/test/Withdrawer.t.sol
+++ b/test/Withdrawer.t.sol
@@ -167,7 +167,6 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     );
 
     vm.prank(depositor_);
-    vm.expectRevert(IWithdrawerErrors.InvalidWithdraw.selector);
     rewardsManager.withdrawRewardAssets(DEFAULT_REWARD_POOL_ID, 1, depositor_);
 
     RewardPool memory pool = getRewardPool(rewardsManager, DEFAULT_REWARD_POOL_ID);

--- a/test/Withdrawer.t.sol
+++ b/test/Withdrawer.t.sol
@@ -5,7 +5,6 @@ import {IDripModel} from "cozy-safety-module-libs/interfaces/IDripModel.sol";
 import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
 import {MathConstants} from "cozy-safety-module-libs/lib/MathConstants.sol";
 import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
-import {IWithdrawerErrors} from "../src/interfaces/IWithdrawerErrors.sol";
 import {IWithdrawerEvents} from "../src/interfaces/IWithdrawerEvents.sol";
 import {IRewardsManager} from "../src/interfaces/IRewardsManager.sol";
 import {AssetPool, StakePool, RewardPool} from "../src/lib/structs/Pools.sol";
@@ -308,39 +307,6 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
       rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, depositor_),
       depositAmount_,
       "New deposit should work in new epoch"
-    );
-  }
-
-  function test_oldEpochDepositorCannotStealFromNewEpoch() public {
-    address oldDepositor_ = address(0x1);
-    address newDepositor_ = address(0x2);
-    uint256 depositAmount_ = 100e18;
-
-    // Old depositor in epoch 0
-    _depositRewardAssets(oldDepositor_, depositAmount_);
-
-    // Epoch transition
-    _performDrip(WAD);
-
-    // New depositor in epoch 1
-    _depositRewardAssets(newDepositor_, depositAmount_ * 2);
-
-    // Old depositor tries to withdraw
-    assertEq(
-      rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, oldDepositor_),
-      0,
-      "Old depositor should have 0"
-    );
-
-    vm.prank(oldDepositor_);
-    vm.expectRevert(IWithdrawerErrors.InvalidWithdraw.selector);
-    rewardsManager.withdrawRewardAssets(DEFAULT_REWARD_POOL_ID, 1, oldDepositor_);
-
-    // New depositor can withdraw their full amount
-    assertEq(
-      rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, newDepositor_),
-      depositAmount_ * 2,
-      "New depositor should have full amount"
     );
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a getter to view a depositor’s rewards for a specific pool.
  - Withdrawals now auto-advance drips when the system isn’t paused.
  - Zero-amount withdrawals are allowed to trigger drip progression without transferring funds.
  - Using the maximum amount withdraws all currently available rewards.
  - Withdrawals now clamp to available rewards instead of reverting on excess amounts.
- Tests
  - Added coverage for auto-drip withdrawals and zero-amount withdrawals.
  - Removed an obsolete epoch transition test and outdated revert expectation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->