### PR TITLE
Recycle undripped claimable rewards eng-1630

### DIFF
--- a/src/lib/RewardsDistributor.sol
+++ b/src/lib/RewardsDistributor.sol
@@ -185,7 +185,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
 
       {
         // Step (2)
-        ClaimableRewardsData memory newClaimableRewardsData_ = _previewNextClaimableRewardsData(
+        (ClaimableRewardsData memory newClaimableRewardsData_,) = _previewNextClaimableRewardsData(
           claimableRewards_[rewardPoolId_],
           rewardPool_.cumulativeDrippedRewards,
           claimRewardsData_.stkReceiptTokenSupply,
@@ -232,18 +232,19 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     uint256 cumulativeDrippedRewards_,
     uint256 stkReceiptTokenSupply_,
     uint256 rewardsWeight_
-  ) internal pure returns (ClaimableRewardsData memory nextClaimableRewardsData_) {
+  ) internal pure returns (ClaimableRewardsData memory nextClaimableRewardsData_, uint256 unclaimedDrippedRewards_) {
     nextClaimableRewardsData_.cumulativeClaimableRewards = claimableRewardsData_.cumulativeClaimableRewards;
     nextClaimableRewardsData_.indexSnapshot = claimableRewardsData_.indexSnapshot;
+
+    // Round down, in favor of leaving assets in the pool.
+    unclaimedDrippedRewards_ = cumulativeDrippedRewards_.mulDivDown(rewardsWeight_, MathConstants.ZOC)
+      - claimableRewardsData_.cumulativeClaimableRewards;
+
     // If `stkReceiptTokenSupply_ == 0`, then we get a divide by zero error if we try to update the index snapshot. To
     // avoid this, we wait until the `stkReceiptTokenSupply_ > 0`, to apply all accumulated unclaimed dripped rewards to
     // the claimable rewards data. We have to update the index snapshot and cumulative claimed rewards at the same time
     // to keep accounting correct.
     if (stkReceiptTokenSupply_ > 0) {
-      // Round down, in favor of leaving assets in the pool.
-      uint256 unclaimedDrippedRewards_ = cumulativeDrippedRewards_.mulDivDown(rewardsWeight_, MathConstants.ZOC)
-        - claimableRewardsData_.cumulativeClaimableRewards;
-
       nextClaimableRewardsData_.cumulativeClaimableRewards += unclaimedDrippedRewards_;
       // Round down, in favor of leaving assets in the claimable reward pool.
       nextClaimableRewardsData_.indexSnapshot +=
@@ -302,7 +303,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
 
     for (uint16 i = 0; i < nextRewardDrips_.length; i++) {
       RewardPool storage rewardPool_ = rewardPools[i];
-      ClaimableRewardsData memory previewNextClaimableRewardsData_ = _previewNextClaimableRewardsData(
+      (ClaimableRewardsData memory previewNextClaimableRewardsData_,) = _previewNextClaimableRewardsData(
         claimableRewards_[i],
         rewardPool_.cumulativeDrippedRewards + nextRewardDrips_[i].amount,
         stkReceiptTokenSupply_,
@@ -362,7 +363,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
       _dripRewardPool(rewardPool_);
       ClaimableRewardsData storage claimableRewardsData_ = claimableRewards_[i];
 
-      claimableRewards_[i] = _previewNextClaimableRewardsData(
+      (claimableRewards_[i],) = _previewNextClaimableRewardsData(
         claimableRewardsData_, rewardPool_.cumulativeDrippedRewards, stkReceiptTokenSupply_, rewardsWeight_
       );
     }
@@ -384,16 +385,24 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
       uint256 oldCumulativeDrippedRewards_ = rewardPool_.cumulativeDrippedRewards;
       rewardPool_.cumulativeDrippedRewards = 0;
 
+      uint256 totalUnclaimedDrippedRewardsToRecycle_;
       for (uint16 j = 0; j < numStakePools_; j++) {
         StakePool storage stakePool_ = stakePools_[j];
-        ClaimableRewardsData memory claimableRewardsData_ = _previewNextClaimableRewardsData(
-          claimableRewards[j][i],
-          oldCumulativeDrippedRewards_,
-          stakePool_.stkReceiptToken.totalSupply(),
-          stakePool_.rewardsWeight
+        uint256 stakeReceiptTokenSupply_ = stakePool_.stkReceiptToken.totalSupply();
+        (ClaimableRewardsData memory claimableRewardsData_, uint256 unclaimedDrippedRewards_) =
+        _previewNextClaimableRewardsData(
+          claimableRewards[j][i], oldCumulativeDrippedRewards_, stakeReceiptTokenSupply_, stakePool_.rewardsWeight
         );
         claimableRewards[j][i] =
           ClaimableRewardsData({cumulativeClaimableRewards: 0, indexSnapshot: claimableRewardsData_.indexSnapshot});
+
+        // If there were no stakers, we can recycle the unclaimed dripped rewards.
+        if (stakeReceiptTokenSupply_ == 0) totalUnclaimedDrippedRewardsToRecycle_ += unclaimedDrippedRewards_;
+      }
+
+      // Recycle any unclaimed dripped rewards by adding them back to the undripped rewards.
+      if (totalUnclaimedDrippedRewardsToRecycle_ > 0) {
+        rewardPool_.undrippedRewards += totalUnclaimedDrippedRewardsToRecycle_;
       }
     }
   }

--- a/test/RewardsDistributor.t.sol
+++ b/test/RewardsDistributor.t.sol
@@ -1143,6 +1143,84 @@ contract RewardsDistributorDripAndResetCumulativeValuesUnitTest is RewardsDistri
     assertEq(expectedRewardPools_, rewardPools_);
   }
 
+  function test_dripAndResetCumulativeRewardsValues_recyclesOnlyZeroSupplyShare() public {
+    uint16 zeroWeight_ = 4000;
+    uint16 nonZeroWeight_ = uint16(MathConstants.ZOC - zeroWeight_);
+    uint256 mintedSupply_ = 1e18;
+    uint256 wadSquared_ = MathConstants.WAD * MathConstants.WAD;
+
+    MockERC20 zeroStakeAsset_ = new MockERC20("Mock Stake Asset", "MockStakeAsset", 6);
+    MockStkReceiptToken zeroStkReceiptToken_ =
+      new MockStkReceiptToken(address(component), "Mock Stake Receipt Token", "MockStakeReceiptToken", 6);
+    StakePool memory zeroStakePool_ = StakePool({
+      amount: 0,
+      asset: IERC20(address(zeroStakeAsset_)),
+      stkReceiptToken: IReceiptToken(address(zeroStkReceiptToken_)),
+      rewardsWeight: zeroWeight_
+    });
+    component.mockAddStakePool(zeroStakePool_);
+
+    MockERC20 nonZeroStakeAsset_ = new MockERC20("Mock Stake Asset", "MockStakeAsset", 6);
+    MockStkReceiptToken nonZeroStkReceiptToken_ =
+      new MockStkReceiptToken(address(component), "Mock Stake Receipt Token", "MockStakeReceiptToken", 6);
+    nonZeroStkReceiptToken_.mint(address(this), mintedSupply_);
+    StakePool memory nonZeroStakePool_ = StakePool({
+      amount: mintedSupply_,
+      asset: IERC20(address(nonZeroStakeAsset_)),
+      stkReceiptToken: IReceiptToken(address(nonZeroStkReceiptToken_)),
+      rewardsWeight: nonZeroWeight_
+    });
+    component.mockAddStakePool(nonZeroStakePool_);
+
+    MockERC20 rewardAsset_ = new MockERC20("Mock Reward Asset", "MockRewardAsset", 6);
+    RewardPool memory rewardPool_ = RewardPool({
+      undrippedRewards: 10_000,
+      cumulativeDrippedRewards: 1200,
+      lastDripTime: uint128(block.timestamp),
+      asset: IERC20(address(rewardAsset_)),
+      dripModel: IDripModel(address(new MockDripModel(0))),
+      epoch: 5,
+      logIndexSnapshot: 11
+    });
+    component.mockAddRewardPool(rewardPool_);
+
+    ClaimableRewardsData memory zeroClaimable_ =
+      ClaimableRewardsData({cumulativeClaimableRewards: 90, indexSnapshot: 33});
+    component.mockSetClaimableRewardsData(
+      0, 0, uint128(zeroClaimable_.indexSnapshot), uint128(zeroClaimable_.cumulativeClaimableRewards)
+    );
+
+    ClaimableRewardsData memory nonZeroClaimable_ =
+      ClaimableRewardsData({cumulativeClaimableRewards: 200, indexSnapshot: 44});
+    component.mockSetClaimableRewardsData(
+      1, 0, uint128(nonZeroClaimable_.indexSnapshot), uint128(nonZeroClaimable_.cumulativeClaimableRewards)
+    );
+
+    component.dripAndResetCumulativeRewardsValues();
+
+    RewardPool[] memory rewardPools_ = component.getRewardPools();
+    ClaimableRewardsData[] memory zeroClaimableAfter_ = component.getClaimableRewards(0);
+    ClaimableRewardsData[] memory nonZeroClaimableAfter_ = component.getClaimableRewards(1);
+
+    uint256 zeroShare_ = (rewardPool_.cumulativeDrippedRewards * zeroStakePool_.rewardsWeight) / MathConstants.ZOC;
+    uint256 expectedRecycled_ = zeroShare_ - zeroClaimable_.cumulativeClaimableRewards;
+    assertEq(rewardPools_[0].undrippedRewards, rewardPool_.undrippedRewards + expectedRecycled_);
+    assertEq(rewardPools_[0].cumulativeDrippedRewards, 0);
+
+    assertEq(zeroClaimableAfter_[0].cumulativeClaimableRewards, 0);
+    assertEq(zeroClaimableAfter_[0].indexSnapshot, zeroClaimable_.indexSnapshot);
+
+    uint256 nonZeroShare_ = (rewardPool_.cumulativeDrippedRewards * nonZeroStakePool_.rewardsWeight) / MathConstants.ZOC;
+    uint256 expectedNonZeroUnclaimed_ = nonZeroShare_ - nonZeroClaimable_.cumulativeClaimableRewards;
+    uint256 expectedNonZeroIndex_ =
+      nonZeroClaimable_.indexSnapshot + (expectedNonZeroUnclaimed_ * wadSquared_) / mintedSupply_;
+
+    assertEq(nonZeroClaimableAfter_[0].cumulativeClaimableRewards, 0);
+    assertEq(nonZeroClaimableAfter_[0].indexSnapshot, expectedNonZeroIndex_);
+    assertEq(rewardPools_[0].epoch, rewardPool_.epoch);
+    assertEq(rewardPools_[0].logIndexSnapshot, rewardPool_.logIndexSnapshot);
+  }
+
   function test_dripAndResetCumulativeRewardsValuesConcrete() public {
     _setUpConcrete();
     skip(ONE_YEAR);

--- a/test/RewardsDistributor.t.sol
+++ b/test/RewardsDistributor.t.sol
@@ -1135,8 +1135,9 @@ contract RewardsDistributorDripAndResetCumulativeValuesUnitTest is RewardsDistri
     ClaimableRewardsData[][] memory claimableRewards_ = component.getClaimableRewards();
     RewardPool[] memory rewardPools_ = component.getRewardPools();
     expectedRewardPools_[0].lastDripTime = uint128(block.timestamp);
-    expectedRewardPools_[0].undrippedRewards -=
-      _calculateExpectedDripQuantity(expectedRewardPools_[0].undrippedRewards, 0.1e18);
+    // Reward pool undripped rewards should not change because there are no stakers, so the unclaimed dripped rewards
+    // are recycled back to the pool.
+    expectedRewardPools_[0].undrippedRewards = expectedRewardPools_[0].undrippedRewards;
 
     assertEq(claimableRewards_[0][0], _expectedClaimableRewardsData(initialClaimableRewards_[0][0].indexSnapshot));
     assertEq(expectedRewardPools_, rewardPools_);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unclaimed rewards from pools with no stakers are now recycled back into the reward pool instead of being lost.
  * Claimable rewards calculations now round down unclaimed dripped amounts to keep more assets in the pool.
  * Resetting cumulative rewards during config updates no longer reduces undripped rewards when a pool has zero supply.

* **Tests**
  * Added comprehensive tests to validate recycling behavior and accurate resets across zero- and non-zero-supply pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->