### PR TITLE
Remove fee on transfer comment

### DIFF
--- a/src/lib/Depositor.sol
+++ b/src/lib/Depositor.sol
@@ -27,9 +27,6 @@ abstract contract Depositor is RewardsManagerCommon, IDepositorErrors, IDeposito
     RewardPool storage rewardPool_ = rewardPools[rewardPoolId_];
     IERC20 asset_ = rewardPool_.asset;
 
-    // Pull in deposited assets. After the transfer we ensure we no longer need any assets. This check is
-    // required to support fee on transfer tokens, for example if USDT enables a fee.
-    // Also, we need to transfer before minting or ERC777s could reenter.
     asset_.safeTransferFrom(msg.sender, address(this), rewardAssetAmount_);
     _executeRewardDeposit(rewardPoolId_, asset_, rewardAssetAmount_, rewardPool_);
   }

--- a/src/lib/Staker.sol
+++ b/src/lib/Staker.sol
@@ -56,9 +56,6 @@ abstract contract Staker is RewardsManagerCommon {
     IERC20 asset_ = stakePool_.asset;
     AssetPool storage assetPool_ = assetPools[asset_];
 
-    // Pull in stake assets. After the transfer we ensure we no longer need any assets. This check is
-    // required to support fee on transfer tokens, for example if USDT enables a fee.
-    // Also, we need to transfer before minting or ERC777s could reenter.
     asset_.safeTransferFrom(msg.sender, address(this), assetAmount_);
     _assertValidDepositBalance(asset_, assetPool_.amount, assetAmount_);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up inline comments in deposit and stake flows, removing outdated notes about transfer order and reentrancy. No behavioral or API changes.

* **Chores**
  * General comment maintenance to improve code readability. No impact on functionality, performance, or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->