### PR TITLE
Revert "change-rm-depositsstake-to-signature-model-eng-1635"

### DIFF
--- a/src/interfaces/IDepositorEvents.sol
+++ b/src/interfaces/IDepositorEvents.sol
@@ -4,15 +4,10 @@ pragma solidity ^0.8.0;
 interface IDepositorEvents {
   /// @notice Emitted when a user deposits.
   /// @param caller_ The caller of the deposit.
-  /// @param owner_ The owner of the deposited assets.
   /// @param rewardPoolId_ The reward pool ID that the user deposited into.
   /// @param depositAmount_ The amount of the underlying asset deposited.
   /// @param depositFeeAmount_ The amount of the underlying asset used to pay the deposit fee.
   event Deposited(
-    address indexed caller_,
-    address indexed owner_,
-    uint16 indexed rewardPoolId_,
-    uint256 depositAmount_,
-    uint256 depositFeeAmount_
+    address indexed caller_, uint16 indexed rewardPoolId_, uint256 depositAmount_, uint256 depositFeeAmount_
   );
 }

--- a/src/interfaces/IRewardsManager.sol
+++ b/src/interfaces/IRewardsManager.sol
@@ -43,7 +43,7 @@ interface IRewardsManager {
 
   function depositRewardAssets(uint16 rewardPoolId_, uint256 rewardAssetAmount_) external;
 
-  function depositRewardAssetsOnBehalf(uint16 rewardPoolId_, uint256 rewardAssetAmount_, address owner_) external;
+  function depositRewardAssetsWithoutTransfer(uint16 rewardPoolId_, uint256 rewardAssetAmount_) external;
 
   function dripRewardPool(uint16 rewardPoolId_) external;
 
@@ -96,7 +96,7 @@ interface IRewardsManager {
     view
     returns (PreviewClaimableRewards[] memory);
 
-  function previewCurrentWithdrawableRewards(uint16 rewardPoolId_, address owner_) external view returns (uint256);
+  function previewCurrentWithdrawableRewards(uint16 rewardPoolId_, address depositor_) external view returns (uint256);
 
   function receiptTokenFactory() external view returns (address);
 
@@ -108,9 +108,9 @@ interface IRewardsManager {
 
   function stake(uint16 stakePoolId_, uint256 assetAmount_, address receiver_) external;
 
-  function stakeOnBehalf(uint16 stakePoolId_, uint256 assetAmount_, address owner_) external;
-
   function stakePools(uint256 id_) external view returns (StakePool memory);
+
+  function stakeWithoutTransfer(uint16 stakePoolId_, uint256 assetAmount_, address receiver_) external;
 
   function unpause() external;
 

--- a/src/lib/Depositor.sol
+++ b/src/lib/Depositor.sol
@@ -18,31 +18,27 @@ abstract contract Depositor is RewardsManagerCommon, IDepositorErrors, IDeposito
   using SafeERC20 for IERC20;
   using FixedPointMathLib for uint256;
 
-  /// @notice Deposit `rewardAssetAmount_` reward assets held by `msg.sender` into `rewardPoolId_`, crediting
-  /// `msg.sender`.
-  /// @dev `msg.sender` is treated as the owner of the funds and must approve this contract to pull
-  /// `rewardAssetAmount_` of the pool's underlying asset via `transferFrom`.
+  /// @notice Deposit `rewardAssetAmount_` assets into the `rewardPoolId_` reward pool on behalf of `from_`.
+  /// @dev Assumes that `msg.sender` has approved the rewards manager to spend `rewardAssetAmount_` of the reward pool's
+  /// asset.
   /// @param rewardPoolId_ The ID of the reward pool.
   /// @param rewardAssetAmount_ The amount of the reward pool's asset to deposit.
   function depositRewardAssets(uint16 rewardPoolId_, uint256 rewardAssetAmount_) external {
-    _depositRewardAssets(rewardPoolId_, rewardAssetAmount_, msg.sender);
-  }
-
-  /// @notice Deposit `rewardAssetAmount_` reward assets into `rewardPoolId_` by pulling funds from `owner_`.
-  /// @dev `owner_` must approve this contract to pull `rewardAssetAmount_` of the pool's underlying asset via
-  /// `transferFrom`.
-  /// @param rewardPoolId_ The ID of the reward pool.
-  /// @param rewardAssetAmount_ The amount of the reward pool's asset to deposit.
-  /// @param owner_ The address from which the reward assets will be pulled and credited.
-  function depositRewardAssetsOnBehalf(uint16 rewardPoolId_, uint256 rewardAssetAmount_, address owner_) external {
-    _depositRewardAssets(rewardPoolId_, rewardAssetAmount_, owner_);
-  }
-
-  function _depositRewardAssets(uint16 rewardPoolId_, uint256 rewardAssetAmount_, address owner_) internal {
     RewardPool storage rewardPool_ = rewardPools[rewardPoolId_];
     IERC20 asset_ = rewardPool_.asset;
-    asset_.safeTransferFrom(owner_, address(this), rewardAssetAmount_);
-    _executeRewardDeposit(rewardPoolId_, asset_, rewardAssetAmount_, rewardPool_, owner_);
+
+    asset_.safeTransferFrom(msg.sender, address(this), rewardAssetAmount_);
+    _executeRewardDeposit(rewardPoolId_, asset_, rewardAssetAmount_, rewardPool_);
+  }
+
+  /// @notice Deposit `rewardAssetAmount_` assets into the `rewardPoolId_` reward pool.
+  /// @dev Assumes that the user has already transferred `rewardAssetAmount_` of the reward pool's asset to the rewards
+  /// manager.
+  /// @param rewardPoolId_ The ID of the reward pool.
+  /// @param rewardAssetAmount_ The amount of the reward pool's asset to deposit.
+  function depositRewardAssetsWithoutTransfer(uint16 rewardPoolId_, uint256 rewardAssetAmount_) external {
+    RewardPool storage rewardPool_ = rewardPools[rewardPoolId_];
+    _executeRewardDeposit(rewardPoolId_, rewardPool_.asset, rewardAssetAmount_, rewardPool_);
   }
 
   /// @notice Preview the current amount of undripped rewards in the `rewardPoolId_` reward pool with unrealized drip
@@ -63,8 +59,7 @@ abstract contract Depositor is RewardsManagerCommon, IDepositorErrors, IDeposito
     uint16 rewardPoolId_,
     IERC20 token_,
     uint256 rewardAssetAmount_,
-    RewardPool storage rewardPool_,
-    address owner_
+    RewardPool storage rewardPool_
   ) internal {
     if (rewardsManagerState == RewardsManagerState.PAUSED) revert InvalidState();
     _assertValidDepositBalance(token_, assetPools[token_].amount, rewardAssetAmount_);
@@ -76,8 +71,8 @@ abstract contract Depositor is RewardsManagerCommon, IDepositorErrors, IDeposito
     uint256 depositAmount_ = rewardAssetAmount_ - depositFeeAmount_;
 
     uint256 currentWithdrawableRewards_ =
-      _previewCurrentWithdrawableRewards(rewardPool_, depositorRewards[rewardPoolId_][owner_]);
-    depositorRewards[rewardPoolId_][owner_] = DepositorRewardsData({
+      _previewCurrentWithdrawableRewards(rewardPool_, depositorRewards[rewardPoolId_][msg.sender]);
+    depositorRewards[rewardPoolId_][msg.sender] = DepositorRewardsData({
       withdrawableRewards: currentWithdrawableRewards_ + depositAmount_,
       logIndexSnapshot: rewardPool_.logIndexSnapshot,
       epoch: rewardPool_.epoch
@@ -86,7 +81,7 @@ abstract contract Depositor is RewardsManagerCommon, IDepositorErrors, IDeposito
     assetPools[token_].amount += depositAmount_;
     token_.safeTransfer(cozyManager.owner(), depositFeeAmount_);
 
-    emit Deposited(msg.sender, owner_, rewardPoolId_, depositAmount_, depositFeeAmount_);
+    emit Deposited(msg.sender, rewardPoolId_, depositAmount_, depositFeeAmount_);
   }
 
   function _assertValidDepositBalance(IERC20 token_, uint256 assetPoolBalance_, uint256 depositAmount_)

--- a/src/lib/Staker.sol
+++ b/src/lib/Staker.sol
@@ -15,16 +15,14 @@ abstract contract Staker is RewardsManagerCommon {
 
   /// @notice Emitted when a user stakes.
   /// @param caller_ The address that called the stake function.
-  /// @param owner_ The owner of the staked assets.
   /// @param receiver_ The address that received the stkReceiptTokens.
   /// @param stakePoolId_ The stake pool ID that the user staked in.
   /// @param stkReceiptToken_ The stkReceiptToken that was minted.
   /// @param assetAmount_ The amount of the underlying asset staked.
   event Staked(
     address indexed caller_,
-    address indexed owner_,
     address indexed receiver_,
-    uint16 stakePoolId_,
+    uint16 indexed stakePoolId_,
     IReceiptToken stkReceiptToken_,
     uint256 assetAmount_
   );
@@ -45,38 +43,42 @@ abstract contract Staker is RewardsManagerCommon {
     uint256 stkReceiptTokenAmount_
   );
 
-  /// @notice Stake by transferring `assetAmount_` of the `stakePoolId_` asset from `msg.sender` and minting
-  /// `assetAmount_` stkReceiptTokens to `receiver_`.
-  /// @dev `msg.sender` must be the owner of the staked assets and approve this contract to pull `assetAmount_` via
-  /// `transferFrom` before minting occurs.
+  /// @notice Stake by minting `assetAmount_` stkReceiptTokens to `receiver_` after depositing exactly `assetAmount_` of
+  /// `stakePoolId_` stake pool asset.
+  /// @dev Assumes that `msg.sender` has already approved this contract to transfer `assetAmount_` of the `stakePoolId_`
+  /// stake pool asset.
   /// @param stakePoolId_ The ID of the stake pool to stake in.
   /// @param assetAmount_ The amount of the underlying asset to stake.
   /// @param receiver_ The address that will receive the stkReceiptTokens.
   function stake(uint16 stakePoolId_, uint256 assetAmount_, address receiver_) external {
-    _stake(stakePoolId_, assetAmount_, receiver_, msg.sender);
-  }
-
-  /// @notice Stake on behalf of `owner_` by moving `assetAmount_` of the `stakePoolId_` asset from `owner_` and minting
-  /// the corresponding stkReceiptTokens directly to `owner_`.
-  /// @dev `owner_` must approve this contract to pull `assetAmount_` of the stake asset via `transferFrom`.
-  /// @param stakePoolId_ The ID of the stake pool to stake in.
-  /// @param assetAmount_ The amount of the underlying asset to stake.
-  /// @param owner_ The address from which the assets will be pulled and that will receive the stkReceiptTokens.
-  function stakeOnBehalf(uint16 stakePoolId_, uint256 assetAmount_, address owner_) external {
-    _stake(stakePoolId_, assetAmount_, owner_, owner_);
-  }
-
-  function _stake(uint16 stakePoolId_, uint256 assetAmount_, address receiver_, address owner_) internal {
     if (assetAmount_ == 0) revert AmountIsZero();
 
     StakePool storage stakePool_ = stakePools[stakePoolId_];
     IERC20 asset_ = stakePool_.asset;
     AssetPool storage assetPool_ = assetPools[asset_];
 
-    asset_.safeTransferFrom(owner_, address(this), assetAmount_);
+    asset_.safeTransferFrom(msg.sender, address(this), assetAmount_);
     _assertValidDepositBalance(asset_, assetPool_.amount, assetAmount_);
 
-    _executeStake(stakePoolId_, assetAmount_, receiver_, assetPool_, stakePool_, owner_);
+    _executeStake(stakePoolId_, assetAmount_, receiver_, assetPool_, stakePool_);
+  }
+
+  /// @notice Stake by minting `assetAmount_` stkReceiptTokens to `receiver_`.
+  /// @dev Assumes that `assetAmount_` of `stakePoolId_` stake pool asset has already been transferred to this rewards
+  /// manager contract.
+  /// @param stakePoolId_ The ID of the stake pool to stake in.
+  /// @param assetAmount_ The amount of the underlying asset to stake.
+  /// @param receiver_ The address that will receive the stkReceiptTokens.
+  function stakeWithoutTransfer(uint16 stakePoolId_, uint256 assetAmount_, address receiver_) external {
+    if (assetAmount_ == 0) revert AmountIsZero();
+
+    StakePool storage stakePool_ = stakePools[stakePoolId_];
+    IERC20 asset_ = stakePool_.asset;
+    AssetPool storage assetPool_ = assetPools[asset_];
+
+    _assertValidDepositBalance(asset_, assetPool_.amount, assetAmount_);
+
+    _executeStake(stakePoolId_, assetAmount_, receiver_, assetPool_, stakePool_);
   }
 
   /// @notice Unstakes by burning `stkReceiptTokenAmount_` of `stakePoolId_` stake pool stake receipt tokens and
@@ -129,8 +131,7 @@ abstract contract Staker is RewardsManagerCommon {
     uint256 assetAmount_,
     address receiver_,
     AssetPool storage assetPool_,
-    StakePool storage stakePool_,
-    address owner_
+    StakePool storage stakePool_
   ) internal {
     if (rewardsManagerState == RewardsManagerState.PAUSED) revert InvalidState();
 
@@ -146,7 +147,7 @@ abstract contract Staker is RewardsManagerCommon {
     _updateUserRewards(stkReceiptToken_.balanceOf(receiver_), claimableRewards_, userRewards[stakePoolId_][receiver_]);
 
     stkReceiptToken_.mint(receiver_, assetAmount_);
-    emit Staked(msg.sender, owner_, receiver_, stakePoolId_, stkReceiptToken_, assetAmount_);
+    emit Staked(msg.sender, receiver_, stakePoolId_, stkReceiptToken_, assetAmount_);
   }
 
   function _executeUnstake(uint16 stakePoolId_, uint256 stkReceiptTokenAmount_, address receiver_, address owner_)

--- a/test/Depositor.t.sol
+++ b/test/Depositor.t.sol
@@ -24,7 +24,6 @@ import {
 import {MockERC20} from "./utils/MockERC20.sol";
 import {MockManager} from "./utils/MockManager.sol";
 import {TestBase} from "./utils/TestBase.sol";
-import {IDepositorEvents} from "../src/interfaces/IDepositorEvents.sol";
 import "./utils/Stub.sol";
 
 contract DepositorUnitTest is TestBase {
@@ -33,6 +32,11 @@ contract DepositorUnitTest is TestBase {
   MockERC20 mockAsset = new MockERC20("Mock Asset", "MOCK", 6);
   MockManager cozyManager = new MockManager();
   TestableDepositor component = new TestableDepositor(cozyManager);
+
+  /// @dev Emitted when a user deposits rewards.
+  event Deposited(
+    address indexed caller_, uint16 indexed rewardPoolId_, uint256 depositAmount_, uint256 depositFeeAmount_
+  );
 
   event Transfer(address indexed from, address indexed to, uint256 amount);
 
@@ -58,42 +62,27 @@ contract DepositorUnitTest is TestBase {
     deal(address(mockAsset), address(component), initialUndrippedRewards);
   }
 
-  function _deposit(bool isSelfDeposit_, uint16 poolId_, uint256 amountToDeposit_, address owner_, address caller_)
-    internal
-  {
-    if (isSelfDeposit_) {
-      vm.prank(caller_);
-      component.depositRewardAssets(poolId_, amountToDeposit_);
-    } else {
-      vm.prank(caller_);
-      component.depositRewardAssetsOnBehalf(poolId_, amountToDeposit_, owner_);
-    }
+  function _deposit(bool withoutTransfer_, uint16 poolId_, uint256 amountToDeposit_) internal {
+    if (withoutTransfer_) component.depositRewardAssetsWithoutTransfer(poolId_, amountToDeposit_);
+    else component.depositRewardAssets(poolId_, amountToDeposit_);
   }
 
-  function test_depositReward_DepositAndStorageUpdates_selfDeposit() external {
-    _test_depositReward_DepositAndStorageUpdates(true);
-  }
-
-  function test_depositReward_DepositAndStorageUpdates_onBehalfOfDeposit() external {
-    _test_depositReward_DepositAndStorageUpdates(false);
-  }
-
-  function _test_depositReward_DepositAndStorageUpdates(bool isSelfDeposit_) internal {
-    address owner_ = _randomAddress();
-    address caller_ = isSelfDeposit_ ? owner_ : _randomAddress();
+  function test_depositReward_DepositAndStorageUpdates() external {
+    address depositor_ = _randomAddress();
     uint256 amountToDeposit_ = 10e18;
     uint256 depositFeeAmount_ = amountToDeposit_.mulDivUp(DEFAULT_DEPOSIT_FEE, MathConstants.ZOC);
 
     // Mint initial balance for depositor.
-    mockAsset.mint(owner_, amountToDeposit_);
+    mockAsset.mint(depositor_, amountToDeposit_);
     // Approve rewards manager to spend asset.
-    vm.prank(owner_);
+    vm.prank(depositor_);
     mockAsset.approve(address(component), amountToDeposit_);
 
     _expectEmit();
-    emit IDepositorEvents.Deposited(caller_, owner_, 0, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
+    emit Deposited(depositor_, 0, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
 
-    _deposit(isSelfDeposit_, 0, amountToDeposit_, owner_, caller_);
+    vm.prank(depositor_);
+    _deposit(false, 0, amountToDeposit_);
 
     RewardPool memory finalRewardPool_ = component.getRewardPool(0);
     AssetPool memory finalAssetPool_ = component.getAssetPool(IERC20(address(mockAsset)));
@@ -103,35 +92,27 @@ contract DepositorUnitTest is TestBase {
     assertEq(finalAssetPool_.amount, 60e18 - 5e16);
     assertEq(mockAsset.balanceOf(address(component)), 60e18 - 5e16);
 
-    assertEq(mockAsset.balanceOf(owner_), 0);
+    assertEq(mockAsset.balanceOf(depositor_), 0);
     assertEq(mockAsset.balanceOf(cozyManager.owner()), 5e16);
   }
 
-  function test_depositReward_DepositAndStorageUpdatesWithDrip_selfDeposit() external {
-    _test_depositReward_DepositAndStorageUpdatesWithDrip(true);
-  }
-
-  function test_depositReward_DepositAndStorageUpdatesWithDrip_onBehalfOfDeposit() external {
-    _test_depositReward_DepositAndStorageUpdatesWithDrip(false);
-  }
-
-  function _test_depositReward_DepositAndStorageUpdatesWithDrip(bool isSelfDeposit_) internal {
-    address owner_ = _randomAddress();
-    address caller_ = isSelfDeposit_ ? owner_ : _randomAddress();
+  function test_depositReward_DepositAndStorageUpdatesWithDrip() external {
+    address depositor_ = _randomAddress();
     uint256 amountToDeposit_ = 20e18;
     uint256 depositFeeAmount_ = amountToDeposit_.mulDivUp(DEFAULT_DEPOSIT_FEE, MathConstants.ZOC);
 
     // Mint initial balance for depositor.
-    mockAsset.mint(owner_, amountToDeposit_);
+    mockAsset.mint(depositor_, amountToDeposit_);
     // Approve rewards manager to spend asset.
-    vm.prank(owner_);
+    vm.prank(depositor_);
     mockAsset.approve(address(component), amountToDeposit_);
 
     component.mockSetNextRewardsDripAmount(45e18);
 
+    vm.prank(depositor_);
     _expectEmit();
-    emit IDepositorEvents.Deposited(caller_, owner_, 0, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
-    _deposit(isSelfDeposit_, 0, amountToDeposit_, owner_, caller_);
+    emit Deposited(depositor_, 0, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
+    _deposit(false, 0, amountToDeposit_);
 
     RewardPool memory finalRewardPool_ = component.getRewardPool(0);
     AssetPool memory finalAssetPool_ = component.getAssetPool(IERC20(address(mockAsset)));
@@ -141,89 +122,149 @@ contract DepositorUnitTest is TestBase {
     // 50e18 + 20e18
     assertEq(finalAssetPool_.amount, 70e18 - 10e16);
     assertEq(mockAsset.balanceOf(address(component)), 70e18 - 10e16);
-    assertEq(mockAsset.balanceOf(owner_), 0);
+    assertEq(mockAsset.balanceOf(depositor_), 0);
     assertEq(mockAsset.balanceOf(cozyManager.owner()), 10e16);
   }
 
-  function test_depositRewardAssets_RevertWhenPaused_selfDeposit() external {
-    _test_depositRewardAssets_RevertWhenPaused(true);
-  }
-
-  function test_depositRewardAssets_RevertWhenPaused_onBehalfOfDeposit() external {
-    _test_depositRewardAssets_RevertWhenPaused(false);
-  }
-
-  function _test_depositRewardAssets_RevertWhenPaused(bool isSelfDeposit_) internal {
-    address owner_ = _randomAddress();
-    address caller_ = isSelfDeposit_ ? owner_ : _randomAddress();
+  function test_depositRewardAssets_RevertWhenPaused() external {
+    address depositor_ = _randomAddress();
     uint128 amountToDeposit_ = 10e18;
 
     // Mint initial balance for depositor.
-    mockAsset.mint(owner_, amountToDeposit_);
+    mockAsset.mint(depositor_, amountToDeposit_);
 
     // Approve rewards manager to spend asset.
-    vm.prank(owner_);
+    vm.prank(depositor_);
     mockAsset.approve(address(component), amountToDeposit_);
 
     component.mockSetRewardsManagerState(RewardsManagerState.PAUSED);
 
     vm.expectRevert(ICommonErrors.InvalidState.selector);
-    _deposit(isSelfDeposit_, 0, amountToDeposit_, owner_, caller_);
+    vm.prank(depositor_);
+    _deposit(false, 0, amountToDeposit_);
   }
 
-  function test_depositRewards_RevertOutOfBoundsRewardPoolId_selfDeposit() external {
-    _test_depositRewards_RevertOutOfBoundsRewardPoolId(true);
-  }
-
-  function test_depositRewards_RevertOutOfBoundsRewardPoolId_onBehalfOfDeposit() external {
-    _test_depositRewards_RevertOutOfBoundsRewardPoolId(false);
-  }
-
-  function _test_depositRewards_RevertOutOfBoundsRewardPoolId(bool isSelfDeposit_) internal {
-    address owner_ = _randomAddress();
-    address caller_ = isSelfDeposit_ ? owner_ : _randomAddress();
+  function test_depositRewards_RevertOutOfBoundsRewardPoolId() external {
+    address depositor_ = _randomAddress();
 
     _expectPanic(INDEX_OUT_OF_BOUNDS);
-    _deposit(isSelfDeposit_, 1, 10e18, owner_, caller_);
+    vm.prank(depositor_);
+    _deposit(false, 1, 10e18);
   }
 
-  function testFuzz_depositRewards_RevertInsufficientAssetsAvailable_selfDeposit(uint256 amountToDeposit_) external {
-    _testFuzz_depositRewards_RevertInsufficientAssetsAvailable(true, amountToDeposit_);
-  }
-
-  function testFuzz_depositRewards_RevertInsufficientAssetsAvailable_onBehalfOfDeposit(uint256 amountToDeposit_)
-    external
-  {
-    _testFuzz_depositRewards_RevertInsufficientAssetsAvailable(false, amountToDeposit_);
-  }
-
-  function _testFuzz_depositRewards_RevertInsufficientAssetsAvailable(bool isSelfDeposit_, uint256 amountToDeposit_)
-    internal
-  {
+  function testFuzz_depositRewards_RevertInsufficientAssetsAvailable(uint256 amountToDeposit_) external {
     amountToDeposit_ = bound(amountToDeposit_, 1, type(uint216).max);
 
-    address owner_ = _randomAddress();
-    address caller_ = isSelfDeposit_ ? owner_ : _randomAddress();
+    address depositor_ = _randomAddress();
 
     // Mint insufficient assets for depositor.
-    mockAsset.mint(owner_, amountToDeposit_ - 1);
+    mockAsset.mint(depositor_, amountToDeposit_ - 1);
     // Approve rewards manager to spend asset.
-    vm.prank(owner_);
+    vm.prank(depositor_);
     mockAsset.approve(address(component), amountToDeposit_);
 
     _expectPanic(PANIC_MATH_UNDEROVERFLOW);
-    _deposit(isSelfDeposit_, 0, amountToDeposit_, owner_, caller_);
+    vm.prank(depositor_);
+    _deposit(false, 0, amountToDeposit_);
   }
 
-  function test_depositReward_MultipleLargeDeposits_selfDeposit() external {
-    _test_depositReward_MultipleLargeDeposits(true);
+  function test_depositRewardAssetsWithoutTransfer_DepositAndStorageUpdates() external {
+    address depositor_ = _randomAddress();
+    uint256 amountToDeposit_ = 10e18;
+    uint256 depositFeeAmount_ = amountToDeposit_.mulDivUp(DEFAULT_DEPOSIT_FEE, MathConstants.ZOC);
+    // Mint initial balance for depositor.
+    mockAsset.mint(depositor_, amountToDeposit_);
+    // Transfer to rewards manager.
+    vm.prank(depositor_);
+    mockAsset.transfer(address(component), amountToDeposit_);
+
+    _expectEmit();
+    emit Deposited(depositor_, 0, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
+
+    vm.prank(depositor_);
+    _deposit(true, 0, amountToDeposit_);
+
+    RewardPool memory finalRewardPool_ = component.getRewardPool(0);
+    AssetPool memory finalAssetPool_ = component.getAssetPool(IERC20(address(mockAsset)));
+    // 50e18 + 10e18 - 5e16
+    assertEq(finalRewardPool_.undrippedRewards, 60e18 - 5e16);
+    // 50e18 + 10e18 - 5e16
+    assertEq(finalAssetPool_.amount, 60e18 - 5e16);
+    assertEq(mockAsset.balanceOf(address(component)), 60e18 - 5e16);
+
+    assertEq(mockAsset.balanceOf(depositor_), 0);
+    assertEq(mockAsset.balanceOf(cozyManager.owner()), 5e16);
   }
 
-  function test_depositReward_MultipleLargeDeposits_onBehalfOfDeposit() external {
-    _test_depositReward_MultipleLargeDeposits(false);
+  function test_depositRewardAssetsWithoutTransfer_DepositAndStorageUpdatesNonZeroSupply() external {
+    address depositor_ = _randomAddress();
+    uint256 amountToDeposit_ = 20e18;
+    uint256 depositFeeAmount_ = amountToDeposit_.mulDivUp(DEFAULT_DEPOSIT_FEE, MathConstants.ZOC);
+
+    // Mint initial balance for depositor.
+    mockAsset.mint(depositor_, amountToDeposit_);
+    // Transfer to rewards manager.
+    vm.prank(depositor_);
+    mockAsset.transfer(address(component), amountToDeposit_);
+
+    _expectEmit();
+    emit Deposited(depositor_, 0, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
+
+    vm.prank(depositor_);
+    _deposit(true, 0, amountToDeposit_);
+
+    RewardPool memory finalRewardPool_ = component.getRewardPool(0);
+    AssetPool memory finalAssetPool_ = component.getAssetPool(IERC20(address(mockAsset)));
+    // 50e18 + 20e18 - 10e16
+    assertEq(finalRewardPool_.undrippedRewards, 70e18 - 10e16);
+    // 50e18 + 20e18 - 10e16
+    assertEq(finalAssetPool_.amount, 70e18 - 10e16);
+    assertEq(mockAsset.balanceOf(address(component)), 70e18 - 10e16);
+
+    assertEq(mockAsset.balanceOf(depositor_), 0);
+    assertEq(mockAsset.balanceOf(cozyManager.owner()), 10e16);
   }
 
-  function _test_depositReward_MultipleLargeDeposits(bool isSelfDeposit_) internal {
+  function test_depositRewardAssetsWithoutTransfer_RevertWhenPaused() external {
+    address depositor_ = _randomAddress();
+    uint128 amountToDeposit_ = 10e18;
+
+    // Mint initial balance for depositor.
+    mockAsset.mint(depositor_, amountToDeposit_);
+    // Transfer to rewards manager.
+    vm.prank(depositor_);
+    mockAsset.transfer(address(component), amountToDeposit_);
+
+    component.mockSetRewardsManagerState(RewardsManagerState.PAUSED);
+
+    vm.expectRevert(ICommonErrors.InvalidState.selector);
+    vm.prank(depositor_);
+    _deposit(true, 0, amountToDeposit_);
+  }
+
+  function test_depositRewardAssetsWithoutTransfer_RevertOutOfBoundsRewardPoolId() external {
+    _expectPanic(INDEX_OUT_OF_BOUNDS);
+    _deposit(true, 1, 10e18);
+  }
+
+  function testFuzz_depositRewardAssetsWithoutTransfer_RevertInsufficientAssetsAvailable(uint256 amountToDeposit_)
+    external
+  {
+    amountToDeposit_ = bound(amountToDeposit_, 1, type(uint128).max);
+    address depositor_ = _randomAddress();
+
+    // Mint insufficient assets for depositor.
+    mockAsset.mint(depositor_, amountToDeposit_ - 1);
+    // Transfer to rewards manager.
+    vm.prank(depositor_);
+    mockAsset.transfer(address(component), amountToDeposit_ - 1);
+
+    vm.expectRevert(IDepositorErrors.InvalidDeposit.selector);
+    vm.prank(depositor_);
+    _deposit(true, 0, amountToDeposit_);
+  }
+
+  function test_depositReward_MultipleLargeDeposits() external {
     MockERC20 mockAsset_ = new MockERC20("Mock Asset", "MOCK", 30);
     uint256 initialUndrippedRewards_ = 100e30;
     RewardPool memory initialRewardPool_ = RewardPool({
@@ -240,21 +281,21 @@ contract DepositorUnitTest is TestBase {
     component.mockAddAssetPool(IERC20(address(mockAsset_)), initialAssetPool_);
     deal(address(mockAsset_), address(component), initialUndrippedRewards_);
 
-    address owner_ = _randomAddress();
-    address caller_ = isSelfDeposit_ ? owner_ : _randomAddress();
+    address depositor_ = _randomAddress();
     uint256 amountToDeposit_ = 1_000_000e30;
     uint256 depositFeeAmount_ = amountToDeposit_.mulDivUp(DEFAULT_DEPOSIT_FEE, MathConstants.ZOC);
 
     // Mint initial balance for depositor.
-    mockAsset_.mint(owner_, amountToDeposit_);
+    mockAsset_.mint(depositor_, amountToDeposit_);
     // Approve rewards manager to spend asset.
-    vm.prank(owner_);
+    vm.prank(depositor_);
     mockAsset_.approve(address(component), amountToDeposit_);
 
     _expectEmit();
-    emit IDepositorEvents.Deposited(caller_, owner_, 1, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
+    emit Deposited(depositor_, 1, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
 
-    _deposit(isSelfDeposit_, 1, amountToDeposit_, owner_, caller_);
+    vm.prank(depositor_);
+    _deposit(false, 1, amountToDeposit_);
 
     RewardPool memory finalRewardPool_ = component.getRewardPool(1);
     AssetPool memory finalAssetPool_ = component.getAssetPool(IERC20(address(mockAsset_)));
@@ -268,15 +309,16 @@ contract DepositorUnitTest is TestBase {
     // Mint some more balance for depositor.
     amountToDeposit_ = 100_000e30;
     depositFeeAmount_ = amountToDeposit_.mulDivUp(DEFAULT_DEPOSIT_FEE, MathConstants.ZOC);
-    mockAsset_.mint(owner_, amountToDeposit_);
+    mockAsset_.mint(depositor_, amountToDeposit_);
     // Approve rewards manager to spend asset.
-    vm.prank(owner_);
+    vm.prank(depositor_);
     mockAsset_.approve(address(component), amountToDeposit_);
 
     _expectEmit();
-    emit IDepositorEvents.Deposited(caller_, owner_, 1, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
+    emit Deposited(depositor_, 1, amountToDeposit_ - depositFeeAmount_, depositFeeAmount_);
 
-    _deposit(isSelfDeposit_, 1, amountToDeposit_, owner_, caller_);
+    vm.prank(depositor_);
+    _deposit(false, 1, amountToDeposit_);
 
     finalRewardPool_ = component.getRewardPool(1);
     finalAssetPool_ = component.getAssetPool(IERC20(address(mockAsset_)));

--- a/test/DripModelIntegration.t.sol
+++ b/test/DripModelIntegration.t.sol
@@ -24,16 +24,19 @@ abstract contract DripModelIntegrationTestSetup is MockDeployProtocol {
   address alice = _randomAddress();
 
   function depositRewards(RewardsManager rewardsManager_, uint256 rewardAssetAmount_) internal {
-    deal(address(rewardAsset), self, rewardAsset.balanceOf(self) + rewardAssetAmount_);
-    rewardAsset.approve(address(rewardsManager_), rewardAssetAmount_);
-
-    rewardsManager_.depositRewardAssets(0, rewardAssetAmount_);
+    deal(
+      address(rewardAsset),
+      address(rewardsManager_),
+      rewardAsset.balanceOf(address(rewardsManager_)) + rewardAssetAmount_
+    );
+    rewardsManager_.depositRewardAssetsWithoutTransfer(0, rewardAssetAmount_);
   }
 
   function stake(RewardsManager rewardsManager_, uint256 stakeAssetAmount_, address receiver_) internal {
-    deal(address(stakeAsset), self, stakeAsset.balanceOf(self) + stakeAssetAmount_);
-    stakeAsset.approve(address(rewardsManager_), stakeAssetAmount_);
-    rewardsManager_.stake(0, stakeAssetAmount_, receiver_);
+    deal(
+      address(stakeAsset), address(rewardsManager_), stakeAsset.balanceOf(address(rewardsManager_)) + stakeAssetAmount_
+    );
+    rewardsManager_.stakeWithoutTransfer(0, stakeAssetAmount_, receiver_);
   }
 
   function _assertRewardDripAmountAndReset(uint256 skipTime_, uint256 expectedClaimedRewards_) internal {

--- a/test/Staker.t.sol
+++ b/test/Staker.t.sol
@@ -43,9 +43,8 @@ contract StakerUnitTest is TestBase {
 
   event Staked(
     address indexed caller_,
-    address indexed owner_,
     address indexed receiver_,
-    uint16 stakePoolId_,
+    uint16 indexed stakePoolId_,
     IReceiptToken stkReceiptToken_,
     uint256 assetAmount_
   );
@@ -92,35 +91,9 @@ contract StakerUnitTest is TestBase {
     vm.mockCall(address(mockStkReceiptToken), abi.encodeWithSelector(IERC20.totalSupply.selector), abi.encode(0));
   }
 
-  function _stake(
-    bool isSelfStake_,
-    uint16 stakePoolId_,
-    uint256 assetAmount_,
-    address receiver_,
-    address staker_,
-    address caller_
-  ) internal {
-    if (isSelfStake_) {
-      vm.prank(caller_);
-      component.stake(stakePoolId_, assetAmount_, receiver_);
-    } else {
-      vm.prank(caller_);
-      component.stakeOnBehalf(stakePoolId_, assetAmount_, staker_);
-    }
-  }
-
-  function test_stake_StkReceiptTokensAndStorageUpdates_NonZeroSupply_selfStake() external {
-    _test_stake_StkReceiptTokensAndStorageUpdates_NonZeroSupply(true);
-  }
-
-  function test_stake_StkReceiptTokensAndStorageUpdates_NonZeroSupply_onBehalfOfStake() external {
-    _test_stake_StkReceiptTokensAndStorageUpdates_NonZeroSupply(false);
-  }
-
-  function _test_stake_StkReceiptTokensAndStorageUpdates_NonZeroSupply(bool isSelfStake_) internal {
+  function test_stake_StkReceiptTokensAndStorageUpdates_NonZeroSupply() external {
     address staker_ = _randomAddress();
-    address caller_ = isSelfStake_ ? staker_ : _randomAddress();
-    address receiver_ = isSelfStake_ ? _randomAddress() : staker_;
+    address receiver_ = _randomAddress();
     uint128 amountToStake_ = 20e18;
 
     // Mint initial safety module receipt token balance for staker.
@@ -130,9 +103,10 @@ contract StakerUnitTest is TestBase {
     mockStakeAsset.approve(address(component), amountToStake_);
 
     _expectEmit();
-    emit Staked(caller_, staker_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountToStake_);
+    emit Staked(staker_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountToStake_);
 
-    _stake(isSelfStake_, 0, amountToStake_, receiver_, staker_, caller_);
+    vm.prank(staker_);
+    component.stake(0, amountToStake_, receiver_);
 
     StakePool memory finalStakePool_ = component.getStakePool(0);
     AssetPool memory finalAssetPool_ = component.getAssetPool(IERC20(address(mockStakeAsset)));
@@ -159,20 +133,11 @@ contract StakerUnitTest is TestBase {
     assertEq(mockStkReceiptToken.balanceOf(receiver_), amountToStake_);
   }
 
-  function test_stake_StkReceiptTokensAndStorageUpdates_ZeroSupply_selfStake() external {
-    _test_stake_StkReceiptTokensAndStorageUpdates_ZeroSupply(true);
-  }
-
-  function test_stake_StkReceiptTokensAndStorageUpdates_ZeroSupply_onBehalfOfStake() external {
-    _test_stake_StkReceiptTokensAndStorageUpdates_ZeroSupply(false);
-  }
-
-  function _test_stake_StkReceiptTokensAndStorageUpdates_ZeroSupply(bool isSelfStake_) internal {
+  function test_stake_StkReceiptTokensAndStorageUpdates_ZeroSupply() external {
     _overrideSetUpToZeroStkReceiptTokenSupply();
 
     address staker_ = _randomAddress();
-    address caller_ = isSelfStake_ ? staker_ : _randomAddress();
-    address receiver_ = isSelfStake_ ? _randomAddress() : staker_;
+    address receiver_ = _randomAddress();
     uint128 amountToStake_ = 20e18;
 
     // Mint initial safety module receipt token balance for staker.
@@ -182,9 +147,10 @@ contract StakerUnitTest is TestBase {
     mockStakeAsset.approve(address(component), amountToStake_);
 
     _expectEmit();
-    emit Staked(caller_, staker_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountToStake_);
+    emit Staked(staker_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountToStake_);
 
-    _stake(isSelfStake_, 0, amountToStake_, receiver_, staker_, caller_);
+    vm.prank(staker_);
+    component.stake(0, amountToStake_, receiver_);
 
     StakePool memory finalStakePool_ = component.getStakePool(0);
     AssetPool memory finalAssetPool_ = component.getAssetPool(IERC20(address(mockStakeAsset)));
@@ -203,18 +169,9 @@ contract StakerUnitTest is TestBase {
     assertEq(mockStkReceiptToken.balanceOf(receiver_), amountToStake_);
   }
 
-  function test_stake_RevertWhenPaused_selfStake() external {
-    _test_stake_RevertWhenPaused(true);
-  }
-
-  function test_stake_RevertWhenPaused_onBehalfOfStake() external {
-    _test_stake_RevertWhenPaused(false);
-  }
-
-  function _test_stake_RevertWhenPaused(bool isSelfStake_) internal {
+  function test_stake_RevertWhenPaused() external {
     address staker_ = _randomAddress();
-    address caller_ = isSelfStake_ ? staker_ : _randomAddress();
-    address receiver_ = isSelfStake_ ? _randomAddress() : staker_;
+    address receiver_ = _randomAddress();
 
     uint256 amountToStake_ = 20e18;
     // Mint initial safety module receipt token balance for staker.
@@ -227,40 +184,24 @@ contract StakerUnitTest is TestBase {
     component.mockSetRewardsManagerState(RewardsManagerState.PAUSED);
 
     vm.expectRevert(ICommonErrors.InvalidState.selector);
-    _stake(isSelfStake_, 0, amountToStake_, receiver_, staker_, caller_);
+    vm.prank(staker_);
+    component.stake(0, amountToStake_, receiver_);
   }
 
-  function test_stake_RevertOutOfBoundsStakePoolId_selfStake() external {
-    _test_stake_RevertOutOfBoundsStakePoolId(true);
-  }
-
-  function test_stake_RevertOutOfBoundsStakePoolId_onBehalfOfStake() external {
-    _test_stake_RevertOutOfBoundsStakePoolId(false);
-  }
-
-  function _test_stake_RevertOutOfBoundsStakePoolId(bool isSelfStake_) internal {
+  function test_stake_RevertOutOfBoundsStakePoolId() external {
     address staker_ = _randomAddress();
-    address caller_ = isSelfStake_ ? staker_ : _randomAddress();
-    address receiver_ = isSelfStake_ ? _randomAddress() : staker_;
+    address receiver_ = _randomAddress();
 
     _expectPanic(INDEX_OUT_OF_BOUNDS);
-    _stake(isSelfStake_, 1, 10e18, receiver_, staker_, caller_);
+    vm.prank(staker_);
+    component.stake(1, 10e18, receiver_);
   }
 
-  function testFuzz_stake_RevertInsufficientAssetsAvailable_selfStake(uint256 amountToStake_) external {
-    _testFuzz_stake_RevertInsufficientAssetsAvailable(true, amountToStake_);
-  }
-
-  function testFuzz_stake_RevertInsufficientAssetsAvailable_onBehalfOfStake(uint256 amountToStake_) external {
-    _testFuzz_stake_RevertInsufficientAssetsAvailable(false, amountToStake_);
-  }
-
-  function _testFuzz_stake_RevertInsufficientAssetsAvailable(bool isSelfStake_, uint256 amountToStake_) internal {
+  function testFuzz_stake_RevertInsufficientAssetsAvailable(uint256 amountToStake_) external {
     amountToStake_ = bound(amountToStake_, 1, type(uint216).max);
 
     address staker_ = _randomAddress();
-    address caller_ = isSelfStake_ ? staker_ : _randomAddress();
-    address receiver_ = isSelfStake_ ? _randomAddress() : staker_;
+    address receiver_ = _randomAddress();
 
     // Mint insufficient safety module receipt tokens for staker.
     mockStakeAsset.mint(staker_, amountToStake_ - 1);
@@ -269,26 +210,140 @@ contract StakerUnitTest is TestBase {
     mockStakeAsset.approve(address(component), amountToStake_);
 
     _expectPanic(PANIC_MATH_UNDEROVERFLOW);
-    _stake(isSelfStake_, 0, amountToStake_, receiver_, staker_, caller_);
+    vm.prank(staker_);
+    component.stake(0, amountToStake_, receiver_);
   }
 
-  function test_stake_RevertZeroShares_selfStake() external {
-    _test_stake_RevertZeroShares(true);
-  }
-
-  function test_stake_RevertZeroShares_onBehalfOfStake() external {
-    _test_stake_RevertZeroShares(false);
-  }
-
-  function _test_stake_RevertZeroShares(bool isSelfStake_) internal {
+  function test_stakeWithoutTransfer_StkReceiptTokensAndStorageUpdates_NonZeroSupply() external {
     address staker_ = _randomAddress();
-    address caller_ = isSelfStake_ ? staker_ : _randomAddress();
-    address receiver_ = isSelfStake_ ? _randomAddress() : staker_;
+    address receiver_ = _randomAddress();
+    uint128 amountToStake_ = 20e18;
+
+    // Mint initial balance for staker.
+    mockStakeAsset.mint(staker_, amountToStake_);
+    // Transfer to rewards manager.
+    vm.prank(staker_);
+    mockStakeAsset.transfer(address(component), amountToStake_);
+
+    _expectEmit();
+    emit Staked(staker_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountToStake_);
+
+    vm.prank(staker_);
+    component.stakeWithoutTransfer(0, amountToStake_, receiver_);
+
+    StakePool memory finalStakePool_ = component.getStakePool(0);
+    AssetPool memory finalAssetPool_ = component.getAssetPool(IERC20(address(mockStakeAsset)));
+    // 100e18 + 20e18
+    assertEq(finalStakePool_.amount, amountToStake_ + initialStakeAmount);
+    assertEq(finalAssetPool_.amount, amountToStake_ + initialStakeAmount);
+    assertEq(mockStakeAsset.balanceOf(address(component)), amountToStake_ + initialStakeAmount);
+
+    assertEq(mockStakeAsset.balanceOf(staker_), 0);
+    assertEq(mockStkReceiptToken.balanceOf(receiver_), amountToStake_);
+  }
+
+  function test_stakeWithoutTransfer_StkReceiptTokensAndStorageUpdates_ZeroSupply() external {
+    _overrideSetUpToZeroStkReceiptTokenSupply();
+
+    address staker_ = _randomAddress();
+    address receiver_ = _randomAddress();
+    uint128 amountToStake_ = 20e18;
+
+    // Mint initial safety module receipt token balance for staker.
+    mockStakeAsset.mint(staker_, amountToStake_);
+    // Transfer to rewards manager.
+    vm.prank(staker_);
+    mockStakeAsset.transfer(address(component), amountToStake_);
+
+    _expectEmit();
+    emit Staked(staker_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountToStake_);
+
+    vm.prank(staker_);
+    component.stakeWithoutTransfer(0, amountToStake_, receiver_);
+
+    StakePool memory finalStakePool_ = component.getStakePool(0);
+    AssetPool memory finalAssetPool_ = component.getAssetPool(IERC20(address(mockStakeAsset)));
+    ClaimableRewardsData memory finalClaimableRewardsData_ = component.getClaimableRewardsData(0, 0);
+
+    assertEq(finalStakePool_.amount, amountToStake_);
+    assertEq(finalAssetPool_.amount, amountToStake_);
+    assertEq(mockStakeAsset.balanceOf(address(component)), amountToStake_);
+
+    // Because `stkReceiptToken.totalSupply() == 0` when the user stakes, the index snapshot and cumulative claimed
+    // rewards
+    // should not change.
+    assertEq(finalClaimableRewardsData_.indexSnapshot, initialIndexSnapshot_);
+    assertEq(finalClaimableRewardsData_.cumulativeClaimableRewards, cumulativeClaimableRewards_);
+    assertEq(mockStakeAsset.balanceOf(staker_), 0);
+    assertEq(mockStkReceiptToken.balanceOf(receiver_), amountToStake_);
+  }
+
+  function test_stakeWithoutTransfer_RevertWhenPaused() external {
+    address staker_ = _randomAddress();
+    address receiver_ = _randomAddress();
+
+    // Mint initial safety module receipt token balance for rewards manager.
+    mockStakeAsset.mint(address(component), 150e18);
+
+    uint256 amountToStake_ = 20e18;
+    // Mint initial safety module receipt token balance for staker.
+    mockStakeAsset.mint(staker_, amountToStake_);
+
+    // Transfer to rewards manager.
+    vm.prank(staker_);
+    mockStakeAsset.transfer(address(component), amountToStake_);
+
+    component.mockSetRewardsManagerState(RewardsManagerState.PAUSED);
+
+    vm.expectRevert(ICommonErrors.InvalidState.selector);
+    vm.prank(staker_);
+    component.stakeWithoutTransfer(0, amountToStake_, receiver_);
+  }
+
+  function test_stakeWithoutTransfer_RevertOutOfBoundsStakePoolId() external {
+    address receiver_ = _randomAddress();
+
+    _expectPanic(INDEX_OUT_OF_BOUNDS);
+    component.stakeWithoutTransfer(1, 10e18, receiver_);
+  }
+
+  function testFuzz_stakeWithoutTransfer_RevertInsufficientAssetsAvailable(uint256 amountToStake_) external {
+    amountToStake_ = bound(amountToStake_, 1, type(uint216).max);
+
+    address staker_ = _randomAddress();
+    address receiver_ = _randomAddress();
+
+    // Mint safety module receipt tokens for staker.
+    mockStakeAsset.mint(staker_, amountToStake_);
+    // Transfer insufficient safety module receipt tokens to safety module.
+    vm.prank(staker_);
+    mockStakeAsset.transfer(address(component), amountToStake_ - 1);
+
+    vm.expectRevert(IDepositorErrors.InvalidDeposit.selector);
+    vm.prank(staker_);
+    component.stakeWithoutTransfer(0, amountToStake_, receiver_);
+  }
+
+  function test_stake_RevertZeroShares() external {
+    address staker_ = _randomAddress();
+    address receiver_ = _randomAddress();
     uint256 amountToStake_ = 0;
 
     // 0 assets should give 0 shares.
     vm.expectRevert(ICommonErrors.AmountIsZero.selector);
-    _stake(isSelfStake_, 0, amountToStake_, receiver_, staker_, caller_);
+    vm.prank(staker_);
+    component.stake(0, amountToStake_, receiver_);
+  }
+
+  function test_stakeWithoutTransfer_RevertZeroShares() external {
+    address staker_ = _randomAddress();
+    address receiver_ = _randomAddress();
+    uint256 amountToStake_ = 0;
+
+    // 0 assets should give 0 shares.
+    vm.expectRevert(ICommonErrors.AmountIsZero.selector);
+    vm.prank(staker_);
+    component.stakeWithoutTransfer(0, amountToStake_, receiver_);
   }
 
   function _setupDefaultSingleUserFixture()
@@ -306,7 +361,7 @@ contract StakerUnitTest is TestBase {
     mockStakeAsset.approve(address(component), amountStaked_);
 
     _expectEmit();
-    emit Staked(staker_, staker_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountStaked_);
+    emit Staked(staker_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountStaked_);
 
     vm.prank(staker_);
     component.stake(0, amountStaked_, receiver_);

--- a/test/benchmarks/BenchmarkMaxPools.t.sol
+++ b/test/benchmarks/BenchmarkMaxPools.t.sol
@@ -91,24 +91,22 @@ abstract contract BenchmarkMaxPools is MockDeployProtocol {
 
   function _setUpDepositRewardAssets(uint16 rewardPoolId_) internal {
     RewardPool memory rewardPool_ = getRewardPool(IRewardsManager(address(rewardsManager)), rewardPoolId_);
-    deal(address(rewardPool_.asset), self, type(uint256).max);
-    rewardPool_.asset.approve(address(rewardsManager), type(uint256).max);
+    deal(address(rewardPool_.asset), address(rewardsManager), type(uint256).max);
   }
 
   function _depositRewardAssets(uint16 rewardPoolId_, uint256 rewardAssetAmount_) internal {
     _setUpDepositRewardAssets(rewardPoolId_);
-    rewardsManager.depositRewardAssets(rewardPoolId_, rewardAssetAmount_);
+    rewardsManager.depositRewardAssetsWithoutTransfer(rewardPoolId_, rewardAssetAmount_);
   }
 
   function _setUpStake(uint16 stakePoolId_) internal {
     StakePool memory stakePool_ = getStakePool(IRewardsManager(address(rewardsManager)), stakePoolId_);
-    deal(address(stakePool_.asset), self, type(uint256).max);
-    stakePool_.asset.approve(address(rewardsManager), type(uint256).max);
+    deal(address(stakePool_.asset), address(rewardsManager), type(uint256).max);
   }
 
   function _stake(uint16 stakePoolId_, uint256 stakeAssetAmount_, address receiver_) internal {
     _setUpStake(stakePoolId_);
-    rewardsManager.stake(stakePoolId_, stakeAssetAmount_, receiver_);
+    rewardsManager.stakeWithoutTransfer(stakePoolId_, stakeAssetAmount_, receiver_);
   }
 
   function _setUpUnstake(uint16 stakePoolId_, uint256 stakeAssetAmount_, address receiver_) internal {
@@ -167,8 +165,8 @@ abstract contract BenchmarkMaxPools is MockDeployProtocol {
     _setUpDepositRewardAssets(rewardPoolId_);
 
     uint256 gasInitial_ = gasleft();
-    rewardsManager.depositRewardAssets(rewardPoolId_, rewardAssetAmount_);
-    console2.log("Gas used for depositRewardAssets: %s", gasInitial_ - gasleft());
+    rewardsManager.depositRewardAssetsWithoutTransfer(rewardPoolId_, rewardAssetAmount_);
+    console2.log("Gas used for depositRewardAssetsWithoutTransfer: %s", gasInitial_ - gasleft());
   }
 
   function test_stake() public {
@@ -176,8 +174,8 @@ abstract contract BenchmarkMaxPools is MockDeployProtocol {
     _setUpStake(stakePoolId_);
 
     uint256 gasInitial_ = gasleft();
-    rewardsManager.stake(stakePoolId_, stakeAssetAmount_, receiver_);
-    console2.log("Gas used for stake: %s", gasInitial_ - gasleft());
+    rewardsManager.stakeWithoutTransfer(stakePoolId_, stakeAssetAmount_, receiver_);
+    console2.log("Gas used for stakeWithoutTransfer: %s", gasInitial_ - gasleft());
   }
 
   function test_unstake() public {

--- a/test/invariants/RewardsDepositInvariants.t.sol
+++ b/test/invariants/RewardsDepositInvariants.t.sol
@@ -139,13 +139,10 @@ abstract contract RewardsDepositInvariants is InvariantTestBase {
     uint16 rewardPoolId_ = rewardsManagerHandler.pickValidRewardPoolId(_randomUint256());
     address actor_ = rewardsManagerHandler.pickActor(_randomUint256());
     uint256 assetAmount_ = rewardsManagerHandler.boundDepositAssetAmount(_randomUint256());
-    IERC20 asset_ = getRewardPool(rewardsManager, rewardPoolId_).asset;
-    vm.prank(actor_);
-    asset_.approve(address(rewardsManager), assetAmount_);
 
     vm.prank(actor_);
     vm.expectRevert(IDepositorErrors.InvalidDeposit.selector);
-    rewardsManager.depositRewardAssets(rewardPoolId_, assetAmount_);
+    rewardsManager.depositRewardAssetsWithoutTransfer(rewardPoolId_, assetAmount_);
   }
 }
 

--- a/test/invariants/StakerInvariants.t.sol
+++ b/test/invariants/StakerInvariants.t.sol
@@ -41,7 +41,7 @@ abstract contract StakerInvariants is InvariantTestBase {
       });
     }
 
-    rewardsManagerHandler.stakeWithExistingActorWithoutCountingCall(_randomUint256());
+    rewardsManagerHandler.stakeWithoutTransferWithExistingActorWithoutCountingCall(_randomUint256());
 
     // rewardsManagerHandler.currentStakePoolId is set to the reserve pool that was just deposited into during
     // this invariant test.
@@ -161,26 +161,20 @@ abstract contract StakerInvariants is InvariantTestBase {
   function invariant_cannotStakeZeroAssets() public syncCurrentTimestamp(rewardsManagerHandler) {
     uint16 stakePoolId_ = rewardsManagerHandler.pickValidStakePoolId(_randomUint256());
     address actor_ = rewardsManagerHandler.pickActor(_randomUint256());
-    IERC20 asset_ = getStakePool(rewardsManager, stakePoolId_).asset;
-    vm.prank(actor_);
-    asset_.approve(address(rewardsManager), type(uint256).max);
 
     vm.prank(actor_);
     vm.expectRevert(ICommonErrors.AmountIsZero.selector);
-    rewardsManager.stake(stakePoolId_, 0, actor_);
+    rewardsManager.stakeWithoutTransfer(stakePoolId_, 0, actor_);
   }
 
   function invariant_cannotStakeWithInsufficientAssets() public syncCurrentTimestamp(rewardsManagerHandler) {
     uint16 stakePoolId_ = rewardsManagerHandler.pickValidStakePoolId(_randomUint256());
     address actor_ = rewardsManagerHandler.pickActor(_randomUint256());
     uint256 assetAmount_ = rewardsManagerHandler.boundDepositAssetAmount(_randomUint256());
-    IERC20 asset_ = getStakePool(rewardsManager, stakePoolId_).asset;
-    vm.prank(actor_);
-    asset_.approve(address(rewardsManager), assetAmount_);
 
     vm.prank(actor_);
     vm.expectRevert(IDepositorErrors.InvalidDeposit.selector);
-    rewardsManager.stake(stakePoolId_, assetAmount_, actor_);
+    rewardsManager.stakeWithoutTransfer(stakePoolId_, assetAmount_, actor_);
   }
 }
 

--- a/test/invariants/StateTransitionInvariants.t.sol
+++ b/test/invariants/StateTransitionInvariants.t.sol
@@ -82,6 +82,19 @@ abstract contract StateTransitionInvariantsWithStateTransitions is InvariantTest
     }
   }
 
+  function invariant_depositRewardAssetsWithoutTransferRevertsWhenPaused()
+    public
+    syncCurrentTimestamp(rewardsManagerHandler)
+  {
+    uint16 rewardPoolId_ = rewardsManagerHandler.pickValidRewardPoolId(_randomUint256());
+
+    if (rewardsManager.rewardsManagerState() == RewardsManagerState.PAUSED) {
+      vm.expectRevert(ICommonErrors.InvalidState.selector);
+      vm.prank(_randomAddress());
+      rewardsManager.depositRewardAssetsWithoutTransfer(rewardPoolId_, _randomUint256());
+    }
+  }
+
   function invariant_depositRewardAssetsRevertsWhenPaused() public syncCurrentTimestamp(rewardsManagerHandler) {
     address actor_ = _randomAddress();
     uint16 rewardPoolId_ = rewardsManagerHandler.pickValidRewardPoolId(_randomUint256());
@@ -97,6 +110,24 @@ abstract contract StateTransitionInvariantsWithStateTransitions is InvariantTest
       vm.expectRevert(ICommonErrors.InvalidState.selector);
       vm.prank(actor_);
       rewardsManager.depositRewardAssets(rewardPoolId_, depositAmount_);
+    }
+  }
+
+  function invariant_stakeWithoutTransferRevertsWhenPaused() public syncCurrentTimestamp(rewardsManagerHandler) {
+    address actor_ = _randomAddress();
+    uint16 stakePoolId_ = rewardsManagerHandler.pickValidStakePoolId(_randomUint256());
+    IERC20 asset_ = rewardsManager.stakePools(stakePoolId_).asset;
+
+    uint256 stakeAmount_ = bound(_randomUint64(), 1, type(uint64).max);
+    deal(address(asset_), actor_, stakeAmount_, true);
+
+    vm.prank(actor_);
+    asset_.transfer(address(rewardsManager), stakeAmount_);
+
+    if (rewardsManager.rewardsManagerState() == RewardsManagerState.PAUSED) {
+      vm.expectRevert(ICommonErrors.InvalidState.selector);
+      vm.prank(actor_);
+      rewardsManager.stakeWithoutTransfer(stakePoolId_, stakeAmount_, _randomAddress());
     }
   }
 

--- a/test/invariants/handlers/RewardsManagerHandler.sol
+++ b/test/invariants/handlers/RewardsManagerHandler.sol
@@ -127,6 +127,35 @@ contract RewardsManagerHandler is TestBase {
     return currentActor;
   }
 
+  function depositRewardAssetsWithoutTransfer(uint256 assetAmount_, uint256 seed_)
+    public
+    virtual
+    createActor
+    createActorWithRewardDeposits
+    useValidRewardPoolId(seed_)
+    countCall("depositRewardAssetsWithoutTransfer")
+    advanceTime(seed_)
+    returns (address actor_)
+  {
+    _depositRewardAssetsWithoutTransfer(assetAmount_);
+
+    return currentActor;
+  }
+
+  function depositRewardAssetsWithoutTransferWithExistingActor(uint256 assetAmount_, uint256 seed_)
+    public
+    virtual
+    useActor(seed_)
+    useValidRewardPoolId(seed_)
+    countCall("depositRewardAssetsWithoutTransferWithExistingActor")
+    advanceTime(seed_)
+    returns (address actor_)
+  {
+    _depositRewardAssetsWithoutTransfer(assetAmount_);
+
+    return currentActor;
+  }
+
   function stake(uint256 assetAmount_, uint256 seed_)
     public
     virtual
@@ -156,15 +185,33 @@ contract RewardsManagerHandler is TestBase {
     return currentActor;
   }
 
-  function stakeWithExistingActorWithoutCountingCall(uint256 assets_) external returns (address) {
-    uint256 invalidCallsBefore_ = invalidCalls["stakeWithExistingActor"];
+  function stakeWithoutTransfer(uint256 assetAmount_, uint256 seed_)
+    public
+    virtual
+    createActor
+    createActorWithStakes
+    useValidStakePoolId(seed_)
+    countCall("stakeWithoutTransfer")
+    advanceTime(seed_)
+    returns (address actor_)
+  {
+    _stakeWithoutTransfer(assetAmount_);
 
-    address actor_ = stakeWithExistingActor(assets_, _randomUint256());
+    return currentActor;
+  }
 
-    calls["stakeWithExistingActor"] -= 1; // stakeWithExistingActor increments by 1.
-    if (invalidCallsBefore_ < invalidCalls["stakeWithExistingActor"]) invalidCalls["stakeWithExistingActor"] -= 1;
+  function stakeWithoutTransferWithExistingActor(uint256 assetAmount_, uint256 seed_)
+    public
+    virtual
+    useActor(seed_)
+    useValidStakePoolId(seed_)
+    countCall("stakeWithoutTransferWithExistingActor")
+    advanceTime(seed_)
+    returns (address actor_)
+  {
+    _stakeWithoutTransfer(assetAmount_);
 
-    return actor_;
+    return currentActor;
   }
 
   function unstake(address receiver_, uint256 seed_)
@@ -318,8 +365,15 @@ contract RewardsManagerHandler is TestBase {
     console2.log("");
     console2.log("depositRewardAssets", calls["depositRewardAssets"]);
     console2.log("depositRewardAssetsWithExistingActor", calls["depositRewardAssetsWithExistingActor"]);
+    console2.log("depositRewardAssetsWithoutTransfer", calls["depositRewardAssetsWithoutTransfer"]);
+    console2.log(
+      "depositRewardAssetsWithoutTransferWithExistingActor",
+      calls["depositRewardAssetsWithoutTransferWithExistingActor"]
+    );
     console2.log("stake", calls["stake"]);
     console2.log("stakeWithExistingActor", calls["stakeWithExistingActor"]);
+    console2.log("stakeWithoutTransfer", calls["stakeWithoutTransfer"]);
+    console2.log("stakeWithoutTransferWithExistingActor", calls["stakeWithoutTransferWithExistingActor"]);
     console2.log("unstake", calls["unstake"]);
     console2.log("dripRewards", calls["dripRewards"]);
     console2.log("dripRewardPool", calls["dripRewardPool"]);
@@ -333,8 +387,15 @@ contract RewardsManagerHandler is TestBase {
     console2.log("");
     console2.log("depositRewardAssets", invalidCalls["depositRewardAssets"]);
     console2.log("depositRewardAssetsWithExistingActor", invalidCalls["depositRewardAssetsWithExistingActor"]);
+    console2.log("depositRewardAssetsWithoutTransfer", invalidCalls["depositRewardAssetsWithoutTransfer"]);
+    console2.log(
+      "depositRewardAssetsWithoutTransferWithExistingActor",
+      invalidCalls["depositRewardAssetsWithoutTransferWithExistingActor"]
+    );
     console2.log("stake", invalidCalls["stake"]);
     console2.log("stakeWithExistingActor", invalidCalls["stakeWithExistingActor"]);
+    console2.log("stakeWithoutTransfer", invalidCalls["stakeWithoutTransfer"]);
+    console2.log("stakeWithoutTransferWithExistingActor", invalidCalls["stakeWithoutTransferWithExistingActor"]);
     console2.log("unstake", invalidCalls["unstake"]);
     console2.log("dripRewards", invalidCalls["dripRewards"]);
     console2.log("dripRewardPool", invalidCalls["dripRewardPool"]);
@@ -345,6 +406,17 @@ contract RewardsManagerHandler is TestBase {
     );
     console2.log("pause", invalidCalls["pause"]);
     console2.log("unpause", invalidCalls["unpause"]);
+  }
+
+  function stakeWithoutTransferWithExistingActorWithoutCountingCall(uint256 assets_) external returns (address) {
+    uint256 invalidCallsBefore_ = invalidCalls["stakeWithExistingActor"];
+
+    address actor_ = stakeWithExistingActor(assets_, _randomUint256());
+
+    calls["stakeWithExistingActor"] -= 1; // stakeWithExistingActor increments by 1.
+    if (invalidCallsBefore_ < invalidCalls["stakeWithExistingActor"]) invalidCalls["stakeWithExistingActor"] -= 1;
+
+    return actor_;
   }
 
   function depositRewardAssetsWithExistingActorWithoutCountingCall(uint256 assets_) external returns (address) {
@@ -412,6 +484,20 @@ contract RewardsManagerHandler is TestBase {
     ghost_actorRewardDepositCount[currentActor][currentRewardPoolId] += 1;
   }
 
+  function _depositRewardAssetsWithoutTransfer(uint256 assetAmount_) internal {
+    assetAmount_ = boundDepositAssetAmount(assetAmount_);
+    IERC20 asset_ = getRewardPool(rewardsManager, currentRewardPoolId).asset;
+    _simulateTransferToRewardsManager(asset_, assetAmount_);
+
+    vm.startPrank(currentActor);
+    rewardsManager.depositRewardAssetsWithoutTransfer(currentRewardPoolId, assetAmount_);
+    vm.stopPrank();
+
+    ghost_rewardPoolCumulative[currentRewardPoolId].totalAssetAmount += assetAmount_;
+
+    ghost_actorRewardDepositCount[currentActor][currentRewardPoolId] += 1;
+  }
+
   function _stake(uint256 assetAmount_) internal {
     assetAmount_ = boundDepositAssetAmount(assetAmount_);
     IERC20 asset_ = getStakePool(rewardsManager, currentStakePoolId).asset;
@@ -420,6 +506,21 @@ contract RewardsManagerHandler is TestBase {
     vm.startPrank(currentActor);
     asset_.approve(address(rewardsManager), assetAmount_);
     rewardsManager.stake(currentStakePoolId, assetAmount_, currentActor);
+    vm.stopPrank();
+
+    ghost_stakePoolCumulative[currentStakePoolId].stakeAssetAmount += assetAmount_;
+    ghost_stakePoolCumulative[currentStakePoolId].totalAssetAmount += assetAmount_;
+
+    ghost_actorStakeCount[currentActor][currentStakePoolId] += 1;
+  }
+
+  function _stakeWithoutTransfer(uint256 assetAmount_) internal {
+    assetAmount_ = boundDepositAssetAmount(assetAmount_);
+    IERC20 asset_ = getStakePool(rewardsManager, currentStakePoolId).asset;
+    _simulateTransferToRewardsManager(asset_, assetAmount_);
+
+    vm.startPrank(currentActor);
+    rewardsManager.stakeWithoutTransfer(currentStakePoolId, assetAmount_, currentActor);
     vm.stopPrank();
 
     ghost_stakePoolCumulative[currentStakePoolId].stakeAssetAmount += assetAmount_;

--- a/test/invariants/utils/InvariantTestBase.sol
+++ b/test/invariants/utils/InvariantTestBase.sol
@@ -45,18 +45,22 @@ abstract contract InvariantTestBase is InvariantBaseDeploy {
   }
 
   function _fuzzedSelectors() internal pure virtual returns (bytes4[] memory) {
-    bytes4[] memory selectors = new bytes4[](10);
+    bytes4[] memory selectors = new bytes4[](14);
     selectors[0] = RewardsManagerHandler.depositRewardAssets.selector;
     selectors[1] = RewardsManagerHandler.depositRewardAssetsWithExistingActor.selector;
-    selectors[2] = RewardsManagerHandler.stake.selector;
-    selectors[3] = RewardsManagerHandler.stakeWithExistingActor.selector;
-    selectors[4] = RewardsManagerHandler.unstake.selector;
+    selectors[2] = RewardsManagerHandler.depositRewardAssetsWithoutTransfer.selector;
+    selectors[3] = RewardsManagerHandler.depositRewardAssetsWithoutTransferWithExistingActor.selector;
+    selectors[4] = RewardsManagerHandler.stake.selector;
+    selectors[5] = RewardsManagerHandler.stakeWithExistingActor.selector;
+    selectors[6] = RewardsManagerHandler.stakeWithoutTransfer.selector;
+    selectors[7] = RewardsManagerHandler.stakeWithoutTransferWithExistingActor.selector;
+    selectors[8] = RewardsManagerHandler.unstake.selector;
     // RewardsDistributor selectors
-    selectors[5] = RewardsManagerHandler.dripRewards.selector;
-    selectors[6] = RewardsManagerHandler.dripRewardPool.selector;
-    selectors[7] = RewardsManagerHandler.claimRewards.selector;
-    selectors[8] = RewardsManagerHandler.stkReceiptTokenTransfer.selector;
-    selectors[9] = RewardsManagerHandler.updateUserRewardsForStkReceiptTokenTransfer.selector;
+    selectors[9] = RewardsManagerHandler.dripRewards.selector;
+    selectors[10] = RewardsManagerHandler.dripRewardPool.selector;
+    selectors[11] = RewardsManagerHandler.claimRewards.selector;
+    selectors[12] = RewardsManagerHandler.stkReceiptTokenTransfer.selector;
+    selectors[13] = RewardsManagerHandler.updateUserRewardsForStkReceiptTokenTransfer.selector;
     return selectors;
   }
 
@@ -86,21 +90,25 @@ abstract contract InvariantTestBase is InvariantBaseDeploy {
 
 abstract contract InvariantTestBaseWithStateTransitions is InvariantTestBase {
   function _fuzzedSelectors() internal pure override returns (bytes4[] memory) {
-    bytes4[] memory selectors = new bytes4[](12);
+    bytes4[] memory selectors = new bytes4[](16);
     selectors[0] = RewardsManagerHandler.depositRewardAssets.selector;
     selectors[1] = RewardsManagerHandler.depositRewardAssetsWithExistingActor.selector;
-    selectors[2] = RewardsManagerHandler.stake.selector;
-    selectors[3] = RewardsManagerHandler.stakeWithExistingActor.selector;
-    selectors[4] = RewardsManagerHandler.unstake.selector;
+    selectors[2] = RewardsManagerHandler.depositRewardAssetsWithoutTransfer.selector;
+    selectors[3] = RewardsManagerHandler.depositRewardAssetsWithoutTransferWithExistingActor.selector;
+    selectors[4] = RewardsManagerHandler.stake.selector;
+    selectors[5] = RewardsManagerHandler.stakeWithExistingActor.selector;
+    selectors[6] = RewardsManagerHandler.stakeWithoutTransfer.selector;
+    selectors[7] = RewardsManagerHandler.stakeWithoutTransferWithExistingActor.selector;
+    selectors[8] = RewardsManagerHandler.unstake.selector;
     // RewardsDistributor selectors
-    selectors[5] = RewardsManagerHandler.dripRewards.selector;
-    selectors[6] = RewardsManagerHandler.dripRewardPool.selector;
-    selectors[7] = RewardsManagerHandler.claimRewards.selector;
-    selectors[8] = RewardsManagerHandler.stkReceiptTokenTransfer.selector;
-    selectors[9] = RewardsManagerHandler.updateUserRewardsForStkReceiptTokenTransfer.selector;
+    selectors[9] = RewardsManagerHandler.dripRewards.selector;
+    selectors[10] = RewardsManagerHandler.dripRewardPool.selector;
+    selectors[11] = RewardsManagerHandler.claimRewards.selector;
+    selectors[12] = RewardsManagerHandler.stkReceiptTokenTransfer.selector;
+    selectors[13] = RewardsManagerHandler.updateUserRewardsForStkReceiptTokenTransfer.selector;
     // State transition selectors
-    selectors[10] = RewardsManagerHandler.pause.selector;
-    selectors[11] = RewardsManagerHandler.unpause.selector;
+    selectors[14] = RewardsManagerHandler.pause.selector;
+    selectors[15] = RewardsManagerHandler.unpause.selector;
     return selectors;
   }
 }


### PR DESCRIPTION
Reverts Cozy-Finance/cozy-safety-module-rewards-manager#79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added options to deposit rewards and stake assets without contract-initiated token transfers, enabling pre-funded flows.

- Refactor
  - Simplified deposit and stake flows to be caller-based; removed “on behalf of” operations.
  - Updated deposit and stake events to remove the owner field and adjust parameter ordering.

- Tests
  - Test suite updated to reflect new flows and events, with expanded invariants (including paused-state reverts) and benchmark updates for the new operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->