### PR TITLE
Clean up interfaces in rm eng 1654

### DIFF
--- a/src/interfaces/ICozyManager.sol
+++ b/src/interfaces/ICozyManager.sol
@@ -64,6 +64,12 @@ interface ICozyManager is IGovernable, ICozyManagerEvents {
   /// @notice For the specified RewardsManager, returns the deposit fee.
   function getDepositFee(IRewardsManager rewardsManager_) external view returns (uint16);
 
+  /// @notice Returns the override claim fee configuration for `rewardsManager_` if it exists.
+  function overrideClaimFees(IRewardsManager rewardsManager_) external view returns (uint16 fee, bool exists);
+
+  /// @notice Returns the override deposit fee configuration for `rewardsManager_` if it exists.
+  function overrideDepositFees(IRewardsManager rewardsManager_) external view returns (uint16 fee, bool exists);
+
   /// @notice Batch pauses rewardsManagers_. The manager's pauser or owner can perform this action.
   /// @param rewardsManagers_ The array of rewards managers to pause.
   function pause(IRewardsManager[] calldata rewardsManagers_) external;

--- a/src/interfaces/IRewardsManager.sol
+++ b/src/interfaces/IRewardsManager.sol
@@ -24,8 +24,6 @@ interface IRewardsManager {
 
   function WITHDRAW_REWARD_ASSETS_BY_SIG_TYPEHASH() external view returns (bytes32);
 
-  function acceptOwnership() external;
-
   function allowedRewardPools() external view returns (uint16);
 
   function allowedStakePools() external view returns (uint16);
@@ -131,10 +129,6 @@ interface IRewardsManager {
   function pause(bool[] memory dripRewardPool_) external;
 
   function pauser() external view returns (address);
-
-  function pendingOwner() external view returns (address);
-
-  function transferOwnership(address newOwner_) external;
 
   function updatePauser(address newPauser_) external;
 

--- a/src/interfaces/IRewardsManager.sol
+++ b/src/interfaces/IRewardsManager.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
 import {StakePool, RewardPool, AssetPool} from "../lib/structs/Pools.sol";
 import {
   ClaimableRewardsData,
@@ -15,11 +16,23 @@ import {ICozyManager} from "./ICozyManager.sol";
 import {ClaimRewardsPoolData} from "../lib/structs/Rewards.sol";
 
 interface IRewardsManager {
+  function CLAIM_REWARDS_BY_SIG_ALL_POOLS_TYPEHASH() external view returns (bytes32);
+
+  function CLAIM_REWARDS_BY_SIG_SELECTED_POOLS_TYPEHASH() external view returns (bytes32);
+
+  function CLAIM_REWARDS_POOL_DATA_TYPEHASH() external view returns (bytes32);
+
+  function WITHDRAW_REWARD_ASSETS_BY_SIG_TYPEHASH() external view returns (bytes32);
+
+  function acceptOwnership() external;
+
   function allowedRewardPools() external view returns (uint16);
 
   function allowedStakePools() external view returns (uint16);
 
   function assetPools(IERC20 asset_) external view returns (AssetPool memory);
+
+  function assetToStakePoolIds(IERC20 asset_) external view returns (uint16 index, bool exists);
 
   function claimableRewards(uint16 stakePoolId_, uint16 rewardPoolId_)
     external
@@ -56,12 +69,17 @@ interface IRewardsManager {
     address receiver_
   ) external;
 
-  function cozyManager() external returns (ICozyManager);
+  function cozyManager() external view returns (ICozyManager);
 
   function depositRewardAssets(uint16 rewardPoolId_, uint256 rewardAssetAmount_) external;
 
   function depositRewardAssetsWithoutTransfer(uint16 rewardPoolId_, uint256 rewardAssetAmount_, address owner_)
     external;
+
+  function depositorRewards(uint16 rewardPoolId_, address depositor_)
+    external
+    view
+    returns (uint256 withdrawableRewards, uint256 logIndexSnapshot, uint32 epoch);
 
   function dripRewardPool(uint16 rewardPoolId_) external;
 
@@ -88,6 +106,11 @@ interface IRewardsManager {
 
   function getUserRewards(uint16 stakePoolId_, address user) external view returns (UserRewardsData[] memory);
 
+  function userRewards(uint16 stakePoolId_, address owner_, uint256 rewardPoolIndex_)
+    external
+    view
+    returns (uint256 accruedRewards, uint256 indexSnapshot);
+
   function incrementEIP712Version() external;
 
   function setEIP712DomainName(string calldata name_) external;
@@ -99,6 +122,8 @@ interface IRewardsManager {
     RewardPoolConfig[] calldata rewardPoolConfigs_
   ) external;
 
+  function initialized() external view returns (bool);
+
   function owner() external view returns (address);
 
   function pause() external;
@@ -106,6 +131,12 @@ interface IRewardsManager {
   function pause(bool[] memory dripRewardPool_) external;
 
   function pauser() external view returns (address);
+
+  function pendingOwner() external view returns (address);
+
+  function transferOwnership(address newOwner_) external;
+
+  function updatePauser(address newPauser_) external;
 
   function previewCurrentUndrippedRewards(uint16 rewardPoolId_) external view returns (uint256 nextTotalPoolAmount_);
 
@@ -136,6 +167,11 @@ interface IRewardsManager {
   function stake(uint16 stakePoolId_, uint256 assetAmount_, address receiver_) external;
 
   function stakePools(uint256 id_) external view returns (StakePool memory);
+
+  function stkReceiptTokenToStakePoolIds(IReceiptToken stkReceiptToken_)
+    external
+    view
+    returns (uint16 index, bool exists);
 
   function stakeWithoutTransfer(uint16 stakePoolId_, uint256 assetAmount_, address owner_, address receiver_) external;
 

--- a/src/interfaces/IRewardsManagerFactory.sol
+++ b/src/interfaces/IRewardsManagerFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
+import {ICozyManager} from "./ICozyManager.sol";
 import {IRewardsManager} from "./IRewardsManager.sol";
 import {RewardPoolConfig, StakePoolConfig} from "../lib/structs/Configs.sol";
 
@@ -8,6 +9,9 @@ interface IRewardsManagerFactory {
   /// @dev Emitted when a new Rewards Manager is deployed.
   /// @param rewardsManager The deployed rewards manager.
   event RewardsManagerDeployed(IRewardsManager rewardsManager);
+
+  /// @notice Address of the Cozy protocol manager.
+  function cozyManager() external view returns (ICozyManager);
 
   /// @notice Address of the Rewards Manager logic contract used to deploy new reward managers.
   function rewardsManagerLogic() external view returns (IRewardsManager);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - View access to fee overrides for rewards managers.
  - Read-only getters for depositor/user rewards, pool mappings, and initialization status.
  - Public accessors for EIP-712 typehashes to support signature-based actions.
  - Ability to update the pauser address.
  - Exposed manager accessors on rewards manager and factory; existing accessor is now view-only for safer reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->