### PR TITLE
rm-order-all-params-events-for-ownerreceiver-eng-1655

### DIFF
--- a/src/interfaces/IRewardsDistributorEvents.sol
+++ b/src/interfaces/IRewardsDistributorEvents.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IReceiptToken} from "cozy-safety-module-libs/interfaces/IReceiptToken.sol";
+import {IERC20} from "cozy-safety-module-libs/interfaces/IERC20.sol";
+
+interface IRewardsDistributorEvents {
+  event ClaimedRewards(
+    address indexed caller_,
+    address indexed owner_,
+    address indexed receiver_,
+    uint16 stakePoolId_,
+    uint16 rewardPoolId_,
+    IERC20 rewardAsset_,
+    uint256 amount_,
+    uint256 claimFeeAmount_
+  );
+}

--- a/src/interfaces/IStakerEvents.sol
+++ b/src/interfaces/IStakerEvents.sol
@@ -22,16 +22,16 @@ interface IStakerEvents {
 
   /// @notice Emitted when a user unstakes.
   /// @param caller_ The address that called the unstake function.
-  /// @param receiver_ The address that received the unstaked assets.
   /// @param owner_ The owner of the stkReceiptTokens being unstaked.
+  /// @param receiver_ The address that received the unstaked assets.
   /// @param stakePoolId_ The stake pool ID that the user unstaked from.
   /// @param stkReceiptToken_ The stkReceiptToken that was burned.
   /// @param stkReceiptTokenAmount_ The amount of stkReceiptTokens burned.
   event Unstaked(
-    address caller_,
-    address indexed receiver_,
+    address indexed caller_,
     address indexed owner_,
-    uint16 indexed stakePoolId_,
+    address indexed receiver_,
+    uint16 stakePoolId_,
     IReceiptToken stkReceiptToken_,
     uint256 stkReceiptTokenAmount_
   );

--- a/src/interfaces/IWithdrawerEvents.sol
+++ b/src/interfaces/IWithdrawerEvents.sol
@@ -3,9 +3,16 @@ pragma solidity ^0.8.0;
 
 interface IWithdrawerEvents {
   /// @notice Emitted when reward assets are withdrawn by a depositor.
-  /// @param depositor_ The original rewards depositor.
-  /// @param rewardPoolId_ The reward pool ID that the despotior withdrew from.
-  /// @param withdrawAmount_ The amount of rewards withdrawn.
+  /// @param caller_ The caller of the withdraw function.
+  /// @param owner_ The owner of the deposited funds.
   /// @param receiver_ The receiver of the withdrawn rewards.
-  event Withdrawn(address indexed depositor_, uint16 indexed rewardPoolId_, uint256 withdrawAmount_, address receiver_);
+  /// @param rewardPoolId_ The reward pool ID that the owner withdrew from.
+  /// @param withdrawAmount_ The amount of rewards withdrawn.
+  event Withdrawn(
+    address indexed caller_,
+    address indexed owner_,
+    address indexed receiver_,
+    uint16 rewardPoolId_,
+    uint256 withdrawAmount_
+  );
 }

--- a/src/lib/RewardsDistributor.sol
+++ b/src/lib/RewardsDistributor.sol
@@ -24,8 +24,9 @@ import {
   ClaimRewardsPoolData
 } from "./structs/Rewards.sol";
 import {RewardPool, IdLookup} from "./structs/Pools.sol";
+import {IRewardsDistributorEvents} from "../interfaces/IRewardsDistributorEvents.sol";
 
-abstract contract RewardsDistributor is RewardsManagerCommon {
+abstract contract RewardsDistributor is RewardsManagerCommon, IRewardsDistributorErrors, IRewardsDistributorEvents {
   using FixedPointMathLib for uint256;
   using SafeERC20 for IERC20;
 
@@ -38,16 +39,6 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
 
   bytes32 public constant CLAIM_REWARDS_BY_SIG_SELECTED_POOLS_TYPEHASH = keccak256(
     "ClaimRewardsBySig(uint16[] stakePoolIds,ClaimRewardsPoolData[] claimRewardsPoolData,address owner,address caller,address receiver,uint256 deadline,uint256 nonce)ClaimRewardsPoolData(uint16 rewardPoolId,bool drip)"
-  );
-
-  event ClaimedRewards(
-    uint16 indexed stakePoolId_,
-    uint16 indexed rewardPoolId_,
-    IERC20 rewardAsset_,
-    uint256 amount_,
-    uint256 claimFeeAmount_,
-    address indexed owner_,
-    address receiver_
   );
 
   struct RewardDrip {
@@ -124,9 +115,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
   function claimRewards(uint16 stakePoolId_, ClaimRewardsPoolData[] calldata claimRewardsPoolData_, address receiver_)
     external
   {
-    if (!_checkValidClaimRewardsPoolData(claimRewardsPoolData_)) {
-      revert IRewardsDistributorErrors.InvalidClaimRewardsPoolData();
-    }
+    if (!_checkValidClaimRewardsPoolData(claimRewardsPoolData_)) revert InvalidClaimRewardsPoolData();
     _claimRewards(ClaimRewardsArgs(stakePoolId_, receiver_, msg.sender), claimRewardsPoolData_);
   }
 
@@ -145,9 +134,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     ClaimRewardsPoolData[] calldata claimRewardsPoolData_,
     address receiver_
   ) external {
-    if (!_checkValidClaimRewardsPoolData(claimRewardsPoolData_)) {
-      revert IRewardsDistributorErrors.InvalidClaimRewardsPoolData();
-    }
+    if (!_checkValidClaimRewardsPoolData(claimRewardsPoolData_)) revert InvalidClaimRewardsPoolData();
     for (uint256 i = 0; i < stakePoolIds_.length; i++) {
       _claimRewards(ClaimRewardsArgs(stakePoolIds_[i], receiver_, msg.sender), claimRewardsPoolData_);
     }
@@ -196,9 +183,7 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     uint256 deadline_,
     bytes calldata signature_
   ) external {
-    if (!_checkValidClaimRewardsPoolData(claimRewardsPoolData_)) {
-      revert IRewardsDistributorErrors.InvalidClaimRewardsPoolData();
-    }
+    if (!_checkValidClaimRewardsPoolData(claimRewardsPoolData_)) revert InvalidClaimRewardsPoolData();
 
     bytes32 claimRewardsPoolDataHash_ = _hashClaimRewardsPoolData(claimRewardsPoolData_);
     _claimRewardsBySig(
@@ -448,13 +433,14 @@ abstract contract RewardsDistributor is RewardsManagerCommon {
     args_.rewardAsset.safeTransfer(args_.receiver, claimedAmount_);
 
     emit ClaimedRewards(
+      msg.sender,
+      args_.owner,
+      args_.receiver,
       args_.stakePoolId,
       args_.rewardPoolId,
       args_.rewardAsset,
       claimedAmount_,
-      claimFeeAmount_,
-      args_.owner,
-      args_.receiver
+      claimFeeAmount_
     );
   }
 

--- a/src/lib/Staker.sol
+++ b/src/lib/Staker.sol
@@ -64,9 +64,9 @@ abstract contract Staker is RewardsManagerCommon, IStakerEvents {
   /// dripRewardPool_ instead.
   /// @param stakePoolId_ The ID of the stake pool to unstake from.
   /// @param stkReceiptTokenAmount_ The amount of stkReceiptTokens to unstake.
-  /// @param receiver_ The address that will receive the unstaked assets.
   /// @param owner_ The owner of the stkReceiptTokens being unstaked.
-  function unstake(uint16 stakePoolId_, uint256 stkReceiptTokenAmount_, address receiver_, address owner_) external {
+  /// @param receiver_ The address that will receive the unstaked assets.
+  function unstake(uint16 stakePoolId_, uint256 stkReceiptTokenAmount_, address owner_, address receiver_) external {
     if (stkReceiptTokenAmount_ == 0) revert AmountIsZero();
 
     ClaimRewardsPoolData[] memory claimRewardsPoolData_ = new ClaimRewardsPoolData[](rewardPools.length);
@@ -83,8 +83,8 @@ abstract contract Staker is RewardsManagerCommon, IStakerEvents {
   function unstake(
     uint16 stakePoolId_,
     uint256 stkReceiptTokenAmount_,
-    address receiver_,
     address owner_,
+    address receiver_,
     bool[] memory dripRewardPool_
   ) external {
     if (stkReceiptTokenAmount_ == 0) revert AmountIsZero();
@@ -139,6 +139,6 @@ abstract contract Staker is RewardsManagerCommon, IStakerEvents {
 
     asset_.safeTransfer(receiver_, stkReceiptTokenAmount_);
 
-    emit Unstaked(msg.sender, receiver_, owner_, stakePoolId_, stkReceiptToken_, stkReceiptTokenAmount_);
+    emit Unstaked(msg.sender, owner_, receiver_, stakePoolId_, stkReceiptToken_, stkReceiptTokenAmount_);
   }
 }

--- a/src/lib/Withdrawer.sol
+++ b/src/lib/Withdrawer.sol
@@ -28,8 +28,7 @@ abstract contract Withdrawer is RewardsManagerCommon, IWithdrawerEvents {
   /// rewards will be withdrawn. Else, up to `rewardAssetAmount_` of withdrawable rewards will be withdrawn.
   /// @param receiver_ The address that will receive the withdrawn assets.
   function withdrawRewardAssets(uint16 rewardPoolId_, uint256 rewardAssetAmount_, address receiver_) external {
-    RewardPool storage rewardPool_ = rewardPools[rewardPoolId_];
-    _withdrawRewardAssets(rewardPools[rewardPoolId_], rewardPoolId_, msg.sender, receiver_, rewardAssetAmount_);
+    _withdrawRewardAssets(rewardPoolId_, msg.sender, receiver_, rewardAssetAmount_);
   }
 
   /// @notice Withdraw undripped reward assets on behalf of the owner via permit-style authorization.
@@ -75,16 +74,13 @@ abstract contract Withdrawer is RewardsManagerCommon, IWithdrawerEvents {
 
     eip712Nonces[owner_][WITHDRAW_REWARD_ASSETS_BY_SIG_TYPEHASH] = nonce_ + 1;
 
-    _withdrawRewardAssets(rewardPools[rewardPoolId_], rewardPoolId_, owner_, receiver_, rewardAssetAmount_);
+    _withdrawRewardAssets(rewardPoolId_, owner_, receiver_, rewardAssetAmount_);
   }
 
-  function _withdrawRewardAssets(
-    RewardPool storage rewardPool_,
-    uint16 rewardPoolId_,
-    address owner_,
-    address receiver_,
-    uint256 rewardAssetAmount_
-  ) internal {
+  function _withdrawRewardAssets(uint16 rewardPoolId_, address owner_, address receiver_, uint256 rewardAssetAmount_)
+    internal
+  {
+    RewardPool storage rewardPool_ = rewardPools[rewardPoolId_];
     if (rewardsManagerState != RewardsManagerState.PAUSED) _dripRewardPool(rewardPool_);
     uint256 currentWithdrawableRewards_ =
       _previewCurrentWithdrawableRewards(rewardPool_, depositorRewards[rewardPoolId_][owner_]);

--- a/src/lib/Withdrawer.sol
+++ b/src/lib/Withdrawer.sol
@@ -29,7 +29,7 @@ abstract contract Withdrawer is RewardsManagerCommon, IWithdrawerEvents {
   /// @param receiver_ The address that will receive the withdrawn assets.
   function withdrawRewardAssets(uint16 rewardPoolId_, uint256 rewardAssetAmount_, address receiver_) external {
     RewardPool storage rewardPool_ = rewardPools[rewardPoolId_];
-    _withdrawRewardAssets(rewardPool_, rewardPoolId_, msg.sender, receiver_, rewardAssetAmount_);
+    _withdrawRewardAssets(rewardPools[rewardPoolId_], rewardPoolId_, msg.sender, receiver_, rewardAssetAmount_);
   }
 
   /// @notice Withdraw undripped reward assets on behalf of the owner via permit-style authorization.
@@ -102,7 +102,7 @@ abstract contract Withdrawer is RewardsManagerCommon, IWithdrawerEvents {
 
     rewardPool_.asset.safeTransfer(receiver_, rewardAssetAmount_);
 
-    emit Withdrawn(owner_, rewardPoolId_, rewardAssetAmount_, receiver_);
+    emit Withdrawn(msg.sender, owner_, receiver_, rewardPoolId_, rewardAssetAmount_);
   }
 
   /// @notice Preview the current withdrawable rewards for the owner.

--- a/test/RewardsDistributor.t.sol
+++ b/test/RewardsDistributor.t.sol
@@ -35,8 +35,9 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {TestBase} from "./utils/TestBase.sol";
 import "./utils/Stub.sol";
 import {ClaimRewardsPoolData} from "../src/lib/structs/Rewards.sol";
+import {IRewardsDistributorEvents} from "../src/interfaces/IRewardsDistributorEvents.sol";
 
-contract RewardsDistributorUnitTest is TestBase {
+contract RewardsDistributorUnitTest is TestBase, IRewardsDistributorEvents {
   using FixedPointMathLib for uint256;
 
   MockManager cozyManager = new MockManager();
@@ -44,16 +45,6 @@ contract RewardsDistributorUnitTest is TestBase {
 
   uint256 internal constant ONE_YEAR = 365.25 days;
   uint256 internal constant CLAIM_FEE = 200; // 2%
-
-  event ClaimedRewards(
-    uint16 indexed stakePoolId_,
-    uint16 indexed rewardPoolId_,
-    IERC20 rewardAsset_,
-    uint256 amount_,
-    uint256 claimFeeAmount_,
-    address indexed owner_,
-    address receiver_
-  );
 
   bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
     keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
@@ -530,15 +521,15 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
 
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_
       );
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_
       );
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 2, rewardAssetC_, rewardsReceivedPoolC_, claimFeeAmountC_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 2, rewardAssetC_, rewardsReceivedPoolC_, claimFeeAmountC_
       );
 
       vm.prank(userA_);
@@ -605,15 +596,15 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
 
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_
       );
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_
       );
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 2, rewardAssetC_, rewardsReceivedPoolC_, claimFeeAmountC_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 2, rewardAssetC_, rewardsReceivedPoolC_, claimFeeAmountC_
       );
 
       vm.prank(userA_);
@@ -667,11 +658,11 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
 
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_, userB_, rewardsReceiver_
+        userB_, userB_, rewardsReceiver_, stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_
       );
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_, userB_, rewardsReceiver_
+        userB_, userB_, rewardsReceiver_, stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_
       );
       // Event is not emitted from rewardPoolC because no rewards are transfered.
 
@@ -700,15 +691,15 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
 
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_, userB_, rewardsReceiver_
+        userB_, userB_, rewardsReceiver_, stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_
       );
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_, userB_, rewardsReceiver_
+        userB_, userB_, rewardsReceiver_, stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_
       );
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 2, rewardAssetC_, rewardsReceivedPoolC_, claimFeeAmountC_, userB_, rewardsReceiver_
+        userB_, userB_, rewardsReceiver_, stakePoolId_, 2, rewardAssetC_, rewardsReceivedPoolC_, claimFeeAmountC_
       );
 
       vm.prank(userB_);
@@ -796,7 +787,7 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
 
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_
       );
 
       vm.prank(userA_);
@@ -886,11 +877,11 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
 
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 0, rewardAssetA_, rewardsReceivedPoolA_, claimFeeAmountA_
       );
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 2, rewardAssetC_, rewardsReceivedPoolC_, claimFeeAmountC_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 2, rewardAssetC_, rewardsReceivedPoolC_, claimFeeAmountC_
       );
 
       vm.prank(userA_);
@@ -974,7 +965,7 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
 
       _expectEmit();
       emit ClaimedRewards(
-        stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_, userA_, rewardsReceiver_
+        userA_, userA_, rewardsReceiver_, stakePoolId_, 1, rewardAssetB_, rewardsReceivedPoolB_, claimFeeAmountB_
       );
 
       vm.prank(userA_);
@@ -1375,15 +1366,15 @@ contract RewardsDistributorClaimUnitTest is RewardsDistributorUnitTest {
     uint256 rewardsReceivedPoolC_ = 7054; // 7198 * 0.98
 
     _expectEmit();
-    emit ClaimedRewards(0, 0, rewardAssetA_, 48, 1, user_, receiver_);
+    emit ClaimedRewards(user_, user_, receiver_, 0, 0, rewardAssetA_, 48, 1);
     _expectEmit();
-    emit ClaimedRewards(0, 1, rewardAssetB_, 6_890_625, 140_625, user_, receiver_);
+    emit ClaimedRewards(user_, user_, receiver_, 0, 1, rewardAssetB_, 6_890_625, 140_625);
     _expectEmit();
-    emit ClaimedRewards(1, 0, rewardAssetA_, 2095, 43, user_, receiver_);
+    emit ClaimedRewards(user_, user_, receiver_, 1, 0, rewardAssetA_, 2095, 43);
     _expectEmit();
-    emit ClaimedRewards(1, 1, rewardAssetB_, 407_925_000, 8_325_000, user_, receiver_);
+    emit ClaimedRewards(user_, user_, receiver_, 1, 1, rewardAssetB_, 407_925_000, 8_325_000);
     _expectEmit();
-    emit ClaimedRewards(1, 2, rewardAssetC_, 7054, 144, user_, receiver_);
+    emit ClaimedRewards(user_, user_, receiver_, 1, 2, rewardAssetC_, 7054, 144);
 
     uint16[] memory stakePoolIds_ = new uint16[](2);
     stakePoolIds_[0] = 0;

--- a/test/Staker.t.sol
+++ b/test/Staker.t.sol
@@ -364,10 +364,10 @@ contract StakerUnitTest is TestBase, IStakerEvents {
     _expectEmit();
     emit Transfer(address(component), unstakeReceiver_, amountStaked_);
     _expectEmit();
-    emit Unstaked(receiver_, unstakeReceiver_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountStaked_);
+    emit Unstaked(receiver_, receiver_, unstakeReceiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountStaked_);
 
     vm.prank(receiver_);
-    component.unstake(0, amountStaked_, unstakeReceiver_, receiver_);
+    component.unstake(0, amountStaked_, receiver_, unstakeReceiver_);
 
     assertEq(mockStakeAsset.balanceOf(unstakeReceiver_), amountStaked_);
 
@@ -413,15 +413,15 @@ contract StakerUnitTest is TestBase, IStakerEvents {
     _expectEmit();
     emit Unstaked(
       receiver_,
-      unstakeReceiver_,
       receiver_,
+      unstakeReceiver_,
       0,
       IReceiptToken(address(mockStkReceiptToken)),
       stkReceiptTokenAmountToUnstake_
     );
 
     vm.prank(receiver_);
-    component.unstake(0, stkReceiptTokenAmountToUnstake_, unstakeReceiver_, receiver_);
+    component.unstake(0, stkReceiptTokenAmountToUnstake_, receiver_, unstakeReceiver_);
 
     assertEq(mockStakeAsset.balanceOf(unstakeReceiver_), amountStaked_ / 2);
 
@@ -453,12 +453,12 @@ contract StakerUnitTest is TestBase, IStakerEvents {
     mockStkReceiptToken.approve(address(component), amountStaked_);
 
     vm.prank(receiver_);
-    component.unstake(0, amountStaked_ / 2, unstakeReceiver_, receiver_);
+    component.unstake(0, amountStaked_ / 2, receiver_, unstakeReceiver_);
 
     assertEq(mockStakeAsset.balanceOf(unstakeReceiver_), amountStaked_ / 2);
 
     vm.prank(receiver_);
-    component.unstake(0, amountStaked_ / 2, unstakeReceiver_, receiver_);
+    component.unstake(0, amountStaked_ / 2, receiver_, unstakeReceiver_);
 
     assertEq(mockStakeAsset.balanceOf(unstakeReceiver_), amountStaked_);
 
@@ -488,9 +488,9 @@ contract StakerUnitTest is TestBase, IStakerEvents {
     _expectEmit();
     emit Transfer(address(component), unstakeReceiver_, amountStaked_);
     _expectEmit();
-    emit Unstaked(receiver_, unstakeReceiver_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountStaked_);
+    emit Unstaked(receiver_, receiver_, unstakeReceiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountStaked_);
     vm.prank(receiver_);
-    component.unstake(0, amountStaked_, unstakeReceiver_, receiver_);
+    component.unstake(0, amountStaked_, receiver_, unstakeReceiver_);
 
     assertEq(mockStakeAsset.balanceOf(unstakeReceiver_), amountStaked_);
 
@@ -522,7 +522,7 @@ contract StakerUnitTest is TestBase, IStakerEvents {
 
     vm.expectRevert(ICommonErrors.AmountIsZero.selector);
     vm.prank(receiver_);
-    component.unstake(0, 0, unstakeReceiver_, receiver_);
+    component.unstake(0, 0, receiver_, unstakeReceiver_);
   }
 
   function test_unstake_canUnstakeThroughAllowance() external {
@@ -534,7 +534,7 @@ contract StakerUnitTest is TestBase, IStakerEvents {
     mockStkReceiptToken.approve(spender_, amountStaked_ + 1); // Allowance is 1 extra.
 
     vm.prank(spender_);
-    component.unstake(0, amountStaked_, unstakeReceiver_, receiver_);
+    component.unstake(0, amountStaked_, receiver_, unstakeReceiver_);
 
     assertEq(mockStkReceiptToken.allowance(receiver_, spender_), 1, "stakeReceiptToken allowance"); // Only 1
       // allowance left
@@ -553,7 +553,7 @@ contract StakerUnitTest is TestBase, IStakerEvents {
 
     _expectPanic(PANIC_MATH_UNDEROVERFLOW);
     vm.prank(spender_);
-    component.unstake(0, amountStaked_, unstakeReceiver_, receiver_);
+    component.unstake(0, amountStaked_, receiver_, unstakeReceiver_);
   }
 
   function test_unstake_cannotUnstake_InsufficientTokenBalance() external {
@@ -582,9 +582,6 @@ contract StakerUnitTest is TestBase, IStakerEvents {
     (, address receiver_, uint256 amountStaked_) = _setupDefaultSingleUserFixture();
     address unstakeReceiver_ = _randomAddress();
 
-    vm.prank(receiver_);
-    mockStkReceiptToken.approve(address(component), amountStaked_);
-
     // Add some rewards and skip time so they're claimable (100% drip rate)
     uint256 addtionalRewards_ = 100e6;
     mockAsset.mint(address(component), addtionalRewards_);
@@ -594,10 +591,10 @@ contract StakerUnitTest is TestBase, IStakerEvents {
     _expectEmit();
     emit Transfer(address(component), unstakeReceiver_, amountStaked_);
     _expectEmit();
-    emit Unstaked(receiver_, unstakeReceiver_, receiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountStaked_);
+    emit Unstaked(receiver_, receiver_, unstakeReceiver_, 0, IReceiptToken(address(mockStkReceiptToken)), amountStaked_);
 
     vm.prank(receiver_);
-    component.unstake(0, amountStaked_, unstakeReceiver_, receiver_);
+    component.unstake(0, amountStaked_, receiver_, unstakeReceiver_);
 
     assertEq(mockStakeAsset.balanceOf(unstakeReceiver_), amountStaked_);
     // The owner of the stake receipt tokens should receive the claimable rewards, not the receiver_ of the unstake call
@@ -624,7 +621,7 @@ contract StakerUnitTest is TestBase, IStakerEvents {
 
     vm.prank(receiver_);
     vm.expectRevert(IRewardsDistributorErrors.InvalidLength.selector);
-    component.unstake(0, amountStaked_, unstakeReceiver_, receiver_, dripRewardPool_);
+    component.unstake(0, amountStaked_, receiver_, unstakeReceiver_, dripRewardPool_);
   }
 
   function test_unstake_doesNotDripSelectedRewardPools() public {
@@ -656,7 +653,7 @@ contract StakerUnitTest is TestBase, IStakerEvents {
     skip(100 days);
 
     vm.prank(receiver_);
-    component.unstake(0, amountStaked_, unstakeReceiver_, receiver_, dripRewardPool_);
+    component.unstake(0, amountStaked_, receiver_, unstakeReceiver_, dripRewardPool_);
 
     RewardPool[] memory rewardPools_ = component.getRewardPools();
 

--- a/test/Withdrawer.t.sol
+++ b/test/Withdrawer.t.sol
@@ -140,7 +140,7 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     assertEq(rewardAsset.balanceOf(depositor_), 0, "Depositor should have fully deposited rewards");
 
     _expectEmit();
-    emit IWithdrawerEvents.Withdrawn(depositor_, DEFAULT_REWARD_POOL_ID, depositAmount_, depositor_);
+    emit IWithdrawerEvents.Withdrawn(depositor_, depositor_, depositor_, DEFAULT_REWARD_POOL_ID, depositAmount_);
     vm.prank(depositor_);
     rewardsManager.withdrawRewardAssets(DEFAULT_REWARD_POOL_ID, depositAmount_, depositor_);
 
@@ -174,7 +174,7 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     assertApproxEqRel(withdrawableRewards_, 50e18, 1e15, "Should have 50% remaining after 50% drip");
 
     _expectEmit();
-    emit IWithdrawerEvents.Withdrawn(depositor_, DEFAULT_REWARD_POOL_ID, withdrawableRewards_, depositor_);
+    emit IWithdrawerEvents.Withdrawn(depositor_, depositor_, depositor_, DEFAULT_REWARD_POOL_ID, withdrawableRewards_);
     vm.prank(depositor_);
     rewardsManager.withdrawRewardAssets(DEFAULT_REWARD_POOL_ID, withdrawableRewards_, depositor_);
 
@@ -245,7 +245,7 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     uint256 previewWithdrawable_ = rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, depositor_);
 
     _expectEmit();
-    emit IWithdrawerEvents.Withdrawn(depositor_, DEFAULT_REWARD_POOL_ID, previewWithdrawable_, depositor_);
+    emit IWithdrawerEvents.Withdrawn(depositor_, depositor_, depositor_, DEFAULT_REWARD_POOL_ID, previewWithdrawable_);
     vm.prank(depositor_);
     rewardsManager.withdrawRewardAssets(DEFAULT_REWARD_POOL_ID, type(uint256).max, depositor_);
 
@@ -475,7 +475,7 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
 
     // Alice makes partial withdrawal
     _expectEmit();
-    emit IWithdrawerEvents.Withdrawn(alice_, DEFAULT_REWARD_POOL_ID, 200e18, alice_);
+    emit IWithdrawerEvents.Withdrawn(alice_, alice_, alice_, DEFAULT_REWARD_POOL_ID, 200e18);
     vm.prank(alice_);
     rewardsManager.withdrawRewardAssets(DEFAULT_REWARD_POOL_ID, 200e18, alice_);
     assertApproxEqAbs(rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, alice_), 520e18, 1e16);
@@ -538,7 +538,7 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     uint256 charlieWithdrawableRewards_ =
       rewardsManager.previewCurrentWithdrawableRewards(DEFAULT_REWARD_POOL_ID, charlie_);
     _expectEmit();
-    emit IWithdrawerEvents.Withdrawn(charlie_, DEFAULT_REWARD_POOL_ID, charlieWithdrawableRewards_, charlie_);
+    emit IWithdrawerEvents.Withdrawn(charlie_, charlie_, charlie_, DEFAULT_REWARD_POOL_ID, charlieWithdrawableRewards_);
     vm.prank(charlie_);
     rewardsManager.withdrawRewardAssets(DEFAULT_REWARD_POOL_ID, charlieWithdrawableRewards_, charlie_);
 
@@ -573,7 +573,7 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     bytes memory signature_ = abi.encodePacked(r, s, v);
 
     _expectEmit();
-    emit IWithdrawerEvents.Withdrawn(ownerEOA_, rewardPoolId_, rewardAssetAmount_, receiver_);
+    emit IWithdrawerEvents.Withdrawn(address(this), ownerEOA_, receiver_, rewardPoolId_, rewardAssetAmount_);
 
     rewardsManager.withdrawRewardAssetsBySig(
       rewardPoolId_, rewardAssetAmount_, ownerEOA_, receiver_, deadline_, signature_
@@ -608,7 +608,7 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     bytes memory signature_ = mockSigner_.signMessage(digest_);
 
     _expectEmit();
-    emit IWithdrawerEvents.Withdrawn(owner_, rewardPoolId_, rewardAssetAmount_, receiver_);
+    emit IWithdrawerEvents.Withdrawn(address(this), owner_, receiver_, rewardPoolId_, rewardAssetAmount_);
 
     rewardsManager.withdrawRewardAssetsBySig(
       rewardPoolId_, rewardAssetAmount_, owner_, receiver_, deadline_, signature_
@@ -705,7 +705,7 @@ contract WithdrawerTest is TestBase, MockDeployProtocol {
     );
 
     _expectEmit();
-    emit IWithdrawerEvents.Withdrawn(owner_, rewardPoolId_, rewardAssetAmount_, receiver_);
+    emit IWithdrawerEvents.Withdrawn(authorizedCaller_, owner_, receiver_, rewardPoolId_, rewardAssetAmount_);
 
     vm.prank(authorizedCaller_);
     rewardsManager.withdrawRewardAssetsBySig(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a standardized rewards claim event, exposing caller, owner, receiver, pool IDs, asset, amount, and fee.
- Refactor
  - Unified and reordered event parameters across staking, withdrawing, and rewards claiming to consistently include caller, owner, and receiver, with improved indexing.
  - Updated withdrawal events to include the caller and a new argument order.
  - Adjusted unstake call parameter order to (owner, receiver) for consistency.
- Tests
  - Updated tests to reflect new event formats and parameter orders; added helper utilities for scenario setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->